### PR TITLE
Remove bundles in a detached background process

### DIFF
--- a/e2e/smoke/cases.sh
+++ b/e2e/smoke/cases.sh
@@ -214,6 +214,17 @@ case_cleanup() {
   if [[ -e "$bundle" ]]; then
     fail "bundle ${bundle} still exists after the container exited"
   fi
+
+  # Removal is handed to a detached process, so the staged copy goes shortly after.
+  local waited=0
+  while [[ -e "${bundle}.removing" ]]; do
+    sleep 0.2
+    waited=$((waited + 1))
+    if [[ "$waited" -gt 150 ]]; then
+      fail "staged bundle ${bundle}.removing was never removed"
+      return
+    fi
+  done
 }
 
 main() {

--- a/source/src/bundle.rs
+++ b/source/src/bundle.rs
@@ -3,6 +3,9 @@
 use std::fs;
 use std::io;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -10,6 +13,22 @@ use crate::error::{Error, IoContext, Result};
 use crate::fsutil;
 use crate::log::{log, warning};
 use crate::spec::Spec;
+
+/// Hidden first argument of the detached process that removes a bundle.
+const REMOVE_ARG: &str = "__remove";
+
+/// Suffix given to a bundle once it has been renamed out of the way.
+const REMOVE_SUFFIX: &str = ".removing";
+
+/// The bundle a detached remover was asked to delete, or `None` for an ordinary
+/// invocation. Checked before the launcher sidecar so a bundle path can never
+/// be mistaken for a command line.
+pub fn remover_target(argv: &[String]) -> Option<&str> {
+    match argv {
+        [_, flag, path] if flag == REMOVE_ARG => Some(path.as_str()),
+        _ => None,
+    }
+}
 
 /// A temporary directory holding the bundle and the runtime's state, removed
 /// when this value is dropped.
@@ -60,10 +79,69 @@ impl Drop for Bundle {
             crate::log::warn(format!("keeping bundle at {}", self.root));
             return;
         }
-        if let Err(err) = fsutil::force_remove_dir_all(self.root.as_std_path()) {
-            warning!("could not clean up {}: {err}", self.root);
+        // Renaming first means the bundle is gone the moment this returns, even
+        // though deleting a large rootfs takes far longer than the run itself.
+        let staged = match self.stage_for_removal() {
+            Some(staged) => staged,
+            None => self.root.clone(),
+        };
+        if spawn_remover(&staged) {
+            return;
+        }
+        if let Err(err) = fsutil::force_remove_dir_all(staged.as_std_path()) {
+            warning!("could not clean up {staged}: {err}");
         }
     }
+}
+
+impl Bundle {
+    /// The bundle identifier is random, so the staged name cannot collide.
+    fn stage_for_removal(&self) -> Option<Utf8PathBuf> {
+        let staged = Utf8PathBuf::from(format!("{}{REMOVE_SUFFIX}", self.root));
+        match fs::rename(&self.root, &staged) {
+            Ok(()) => Some(staged),
+            Err(err) => {
+                log!("Could not stage {} for removal: {err}", self.root);
+                None
+            }
+        }
+    }
+}
+
+/// Hands the tree to a copy of this binary that outlives it. Detaching from the
+/// session keeps a terminal signal from orphaning a half deleted tree, and null
+/// standard streams keep the child from holding a caller's pipe open.
+fn spawn_remover(path: &Utf8Path) -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    let mut command = Command::new(exe);
+    command
+        .arg(REMOVE_ARG)
+        .arg(path.as_std_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // SAFETY: setsid is async-signal-safe and touches nothing this process owns.
+    unsafe {
+        command.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+    match command.spawn() {
+        Ok(_) => true,
+        Err(err) => {
+            log!("Could not spawn a background remover for {path}: {err}");
+            false
+        }
+    }
+}
+
+/// Deletes a staged bundle. The exit code is ignored by the parent, so failures
+/// are silent by design: the tree lives under a temporary directory either way.
+pub fn remove_staged(path: &str) {
+    let _ = fsutil::force_remove_dir_all(Path::new(path));
 }
 
 /// Copies the host resolver configuration and writes `/etc/hosts` and
@@ -178,6 +256,37 @@ mod tests {
             bundle.dir().to_owned()
         };
         assert!(!path.exists());
+        // Under `cargo test` the spawned remover is the test binary, which
+        // deletes nothing, so the staged tree is cleared here instead.
+        let _ = fsutil::force_remove_dir_all(parent.as_std_path());
+    }
+
+    #[test]
+    fn removers_are_recognised_by_their_argument_list() {
+        let argv = |args: &[&str]| args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
+        assert_eq!(
+            remover_target(&argv(&["oci_runtime", REMOVE_ARG, "/tmp/bundle"])),
+            Some("/tmp/bundle")
+        );
+        assert_eq!(remover_target(&argv(&["oci_runtime", REMOVE_ARG])), None);
+        assert_eq!(
+            remover_target(&argv(&["oci_runtime", "run", "--layout"])),
+            None
+        );
+        assert_eq!(
+            remover_target(&argv(&["oci_runtime", REMOVE_ARG, "/tmp/bundle", "extra"])),
+            None
+        );
+    }
+
+    #[test]
+    fn staging_moves_the_bundle_aside() {
+        let parent = scratch("bundle-stage");
+        let bundle = Bundle::create(&parent, "abc", true).expect("bundle");
+        let staged = bundle.stage_for_removal().expect("staged");
+        assert_eq!(staged, parent.join(format!("abc{REMOVE_SUFFIX}")));
+        assert!(!bundle.dir().exists());
+        assert!(staged.is_dir());
         let _ = fsutil::force_remove_dir_all(parent.as_std_path());
     }
 

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -23,6 +23,12 @@ use crate::runtime::{ContainerRuntime, RunRequest, Runc};
 use crate::spec::{BindMount, Spec, SpecOptions};
 
 fn main() -> std::process::ExitCode {
+    let argv: Vec<String> = std::env::args().collect();
+    if let Some(path) = bundle::remover_target(&argv) {
+        bundle::remove_staged(path);
+        return std::process::ExitCode::SUCCESS;
+    }
+
     let code = launcher::command_line().and_then(|argv| {
         let cli = match argv {
             Some(argv) => Cli::parse_from(argv),


### PR DESCRIPTION
Deleting the extracted rootfs was the last thing a run did, so the caller waited on it even though nothing depends on the result. The bundle is now renamed to a `.removing` sibling, which is atomic, and the tree is handed to a detached copy of this binary. The bundle path is gone the instant the launcher returns, so `--keep-bundle` and the cleanup assertions keep their meaning.

Running a container that leaves 30000 files behind drops from 1.87s to 1.41s, with the deletion continuing after the prompt returns.

The remover calls setsid so a terminal signal cannot orphan a half deleted tree, and takes null standard streams so it never holds a caller's pipe open. Should the rename or the spawn fail, the tree is deleted inline as before.

Refs #6.