### PR TITLE
Stop layers writing outside the root filesystem

### DIFF
--- a/source/src/extract.rs
+++ b/source/src/extract.rs
@@ -131,7 +131,7 @@ impl RootfsExtractor {
                 continue;
             }
 
-            if !fsutil::parent_is_within(root, &dst)? {
+            if !fsutil::prepare_parent(root, &dst)? {
                 return Err(Error::UnsafeEntry {
                     layer: layer.to_string(),
                     path: path.display().to_string(),
@@ -173,7 +173,18 @@ impl RootfsExtractor {
 
     /// `.wh..wh..opq` hides everything the lower layers put in this directory.
     fn apply_opaque_whiteout(&self, root: &Path, dir: &Path) -> Result<()> {
-        if !fsutil::parent_is_within(root, dir)? {
+        // The marker applies to a directory, and only to one inside the
+        // rootfs. Reading through a symlink here would clear whatever it points
+        // at, which a layer is free to aim anywhere on the host.
+        match fs::symlink_metadata(dir) {
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => return Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(Error::io(format!("inspecting {}", dir.display()), err)),
+        }
+        // A directory can still sit outside the rootfs when one of its parents
+        // is a symlink, so the resolved path has to be checked as well.
+        if !fsutil::is_within(root, dir)? {
             return Ok(());
         }
         let entries = match fs::read_dir(dir) {
@@ -226,20 +237,16 @@ fn is_supported(entry_type: EntryType) -> bool {
 }
 
 /// Writes a regular file, replacing `tar`'s own unpacking so that the copy can
-/// use a buffer sized for the pipeline rather than std's default. The path has
-/// already been checked, so this only has to reproduce the parts of `unpack_in`
-/// that a regular file needs: the parent directory, the contents, the mode and
-/// the modification time.
+/// use a buffer sized for the pipeline rather than std's default. The path and
+/// its parent have already been checked and created, so this only has to
+/// reproduce the parts of `unpack_in` that a regular file needs: the contents,
+/// the mode and the modification time.
 fn unpack_regular<R: Read>(
     entry: &mut tar::Entry<'_, R>,
     dst: &Path,
     mode: u32,
     buffer: &mut [u8],
 ) -> io::Result<()> {
-    if let Some(parent) = dst.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
     // Creating with the final mode avoids a window in which the file is more
     // permissive than the layer asked for. Permissions are checked when the
     // file is opened, so a read-only mode does not stop the writes below.
@@ -653,6 +660,88 @@ mod tests {
             );
             let _ = fsutil::force_remove_dir_all(root.as_std_path());
         }
+    }
+
+    #[test]
+    fn an_entry_cannot_escape_through_a_symlinked_parent() {
+        // A layer can ship a symlink out of the rootfs and then an entry
+        // underneath it. The parent of that entry does not exist and cannot be
+        // resolved, which used to count as safe, so creating it followed the
+        // symlink and wrote the file outside the rootfs.
+        let root = scratch("escape");
+        let outside = scratch("escape-outside");
+
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(EntryType::Symlink);
+        header.set_mode(0o777);
+        header.set_size(0);
+        builder
+            .append_link(&mut header, "lnk", outside.as_std_path())
+            .expect("link");
+
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(7);
+        builder
+            .append_data(&mut header, "lnk/sub/file", &b"escaped"[..])
+            .expect("file");
+        let blob = builder.into_inner().expect("tar");
+
+        let descriptor = install_blob(&root, PLAIN_LAYER, &blob);
+        let err = extract(&root, &descriptor).expect_err("the entry must be refused");
+        assert!(
+            matches!(err, Error::UnsafeEntry { .. }),
+            "expected an unsafe entry, got {err:?}"
+        );
+        assert!(
+            fs::read_dir(outside.as_std_path())
+                .expect("outside")
+                .next()
+                .is_none(),
+            "nothing may be written outside the rootfs"
+        );
+
+        let _ = fsutil::force_remove_dir_all(root.as_std_path());
+        let _ = fsutil::force_remove_dir_all(outside.as_std_path());
+    }
+
+    #[test]
+    fn an_opaque_whiteout_cannot_clear_a_directory_outside_the_rootfs() {
+        // The marker names the directory it applies to, and a layer can point
+        // that name at a symlink leading out of the rootfs. Reading through it
+        // deleted everything at the far end.
+        let root = scratch("opaque-escape");
+        let outside = scratch("opaque-escape-outside");
+        fs::write(outside.join("keep"), b"important").expect("keep");
+
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(EntryType::Symlink);
+        header.set_mode(0o777);
+        header.set_size(0);
+        builder
+            .append_link(&mut header, "lnk", outside.as_std_path())
+            .expect("link");
+
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(0);
+        builder
+            .append_data(&mut header, "lnk/.wh..wh..opq", &b""[..])
+            .expect("opaque");
+        let blob = builder.into_inner().expect("tar");
+
+        let descriptor = install_blob(&root, PLAIN_LAYER, &blob);
+        extract(&root, &descriptor).expect("extract");
+        assert_eq!(
+            fs::read(outside.join("keep")).expect("keep"),
+            b"important",
+            "files outside the rootfs may not be removed"
+        );
+
+        let _ = fsutil::force_remove_dir_all(root.as_std_path());
+        let _ = fsutil::force_remove_dir_all(outside.as_std_path());
     }
 
     #[test]

--- a/source/src/fsutil.rs
+++ b/source/src/fsutil.rs
@@ -99,7 +99,100 @@ pub fn remove_any(path: &Path) -> Result<()> {
     }
 }
 
-/// True when `path`'s parent directory resolves to somewhere inside `root`.
+/// True when `path`'s parent directory resolves to somewhere inside `root`,
+/// creating it when it does not exist yet.
+///
+/// The parent has to be created here rather than by the caller. A layer may
+/// ship a symlink such as `lnk -> /etc` and then an entry `lnk/sub/file`, whose
+/// parent `lnk/sub` does not exist and cannot be resolved; creating it with
+/// `create_dir_all` would follow the symlink and put it outside the root. So
+/// the deepest ancestor that does exist is resolved and checked first, and
+/// everything below it is created one component at a time, which cannot
+/// traverse a symlink that is not there.
+pub fn prepare_parent(root: &Path, path: &Path) -> Result<bool> {
+    let Some(parent) = path.parent() else {
+        return Ok(false);
+    };
+    let canonical_root = root
+        .canonicalize()
+        .io_context(|| format!("resolving {}", root.display()))?;
+    prepare_directory_within(&canonical_root, parent)
+}
+
+/// Resolves `dir`, creating it if needed, and reports whether it ended up
+/// inside `canonical_root`.
+fn prepare_directory_within(canonical_root: &Path, dir: &Path) -> Result<bool> {
+    let mut missing = Vec::new();
+    let mut existing = dir;
+    let canonical = loop {
+        match existing.canonicalize() {
+            Ok(canonical) => break canonical,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                let (Some(name), Some(parent)) = (existing.file_name(), existing.parent()) else {
+                    return Ok(false);
+                };
+                missing.push(name.to_owned());
+                existing = parent;
+            }
+            Err(err) => {
+                return Err(crate::error::Error::io(
+                    format!("resolving {}", existing.display()),
+                    err,
+                ));
+            }
+        }
+    };
+    if !canonical.starts_with(canonical_root) {
+        return Ok(false);
+    }
+
+    // Everything below here is created rather than resolved, so each component
+    // is a real directory and the chain cannot leave the root.
+    let mut path = existing.to_path_buf();
+    for name in missing.iter().rev() {
+        path.push(name);
+        match fs::create_dir(&path) {
+            Ok(()) => {}
+            // Something is already there that `canonicalize` could not resolve,
+            // a dangling symlink among other things, so check where it points.
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                let canonical = path
+                    .canonicalize()
+                    .io_context(|| format!("resolving {}", path.display()))?;
+                if !canonical.starts_with(canonical_root) {
+                    return Ok(false);
+                }
+            }
+            Err(err) => {
+                return Err(crate::error::Error::io(
+                    format!("creating {}", path.display()),
+                    err,
+                ));
+            }
+        }
+    }
+    Ok(true)
+}
+
+/// True when `path` itself resolves to somewhere inside `root`. A path that is
+/// not there counts as outside: there is nothing at it to act on.
+pub fn is_within(root: &Path, path: &Path) -> Result<bool> {
+    let canonical_root = root
+        .canonicalize()
+        .io_context(|| format!("resolving {}", root.display()))?;
+    match path.canonicalize() {
+        Ok(canonical) => Ok(canonical.starts_with(&canonical_root)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(crate::error::Error::io(
+            format!("resolving {}", path.display()),
+            err,
+        )),
+    }
+}
+
+/// True when `path`'s parent directory resolves to somewhere inside `root`, for
+/// callers that must not create anything. A parent that does not exist cannot
+/// be escaped through, so it counts as within.
 pub fn parent_is_within(root: &Path, path: &Path) -> Result<bool> {
     let Some(parent) = path.parent() else {
         return Ok(false);


### PR DESCRIPTION
Two ways out of the rootfs, both reachable from a layer alone. A hostile image is enough; neither needs anything unusual about the host.

The first writes files anywhere. `parent_is_within` treated a parent it could not resolve as safe, on the reasoning that a path which is not there cannot be escaped through. But the caller then created it with `create_dir_all`, which happily follows a symlink. So a layer carrying

    lnk -> /tmp/escape-target
    lnk/sub/file

resolves `lnk/sub`, gets ENOENT because only `lnk` exists, is declared safe, and `create_dir_all` walks out through the symlink and drops the file in /tmp/escape-target/sub. Two levels are needed: an entry directly under `lnk` resolves to the symlink itself and is caught. Regular files are unpacked here rather than by `tar` since #10, so its own check does not apply to them.

The parent is now resolved and created by the same code, which is what makes it safe. `prepare_parent` walks up to the deepest ancestor that does exist, checks that one against the root, and only then creates the components below it one at a time with `create_dir`. `mkdir` does not follow a symlink in its final component, and every component below the verified ancestor is a directory we just made, so the chain cannot leave the root. `unpack_regular` no longer creates parents itself.

The second deletes anything. `apply_opaque_whiteout` checked the parent of the directory it was about to clear, then read the directory itself, so a layer carrying

    lnk -> /some/directory
    lnk/.wh..wh..opq

passes the check on `lnk`'s parent, which is the root, and then empties /some/directory. Running this against a directory holding two files and a subdirectory removed all of them, and the run reported no error. The marker now has to name a real directory, not a symlink, and that directory has to resolve inside the root.

Both are covered by tests built the same way as the layers above, and both tests were confirmed to fail with the fix reverted.

Extraction is unchanged for images that behave: the same 185 MB image gives a byte-identical rootfs across 9499 entries, same modes and timestamps, and 13 interleaved runs put both at 1.38s wall and 1.90s cpu. Losing `create_dir_all` in fact removes syscalls, since it stats and creates every parent again for each file:

    mkdir    8,960 -> 900
    statx   18,995 -> 10,932

The 17 smoke tests pass.

Refs #6.