### PR TITLE
Add a checkpoint index builder for gzip layer blobs

### DIFF
--- a/source/Cargo.Bazel.lock
+++ b/source/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b6c5c8648f57596a0d92004fe1d542b93049b715a89a4b8643e2dac16d1e643a",
+  "checksum": "e71783b6fd9b18f1bb5f2f0fd524d11f6747ed8c9c1cfe5b0b6de4e801c0dd6f",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -1209,7 +1209,7 @@
         "deps": {
           "common": [
             {
-              "id": "zlib-rs 0.6.6",
+              "id": "zlib-rs 0.6.7",
               "target": "zlib_rs"
             }
           ],
@@ -1478,6 +1478,60 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "libz-rs-sys 0.6.7": {
+      "name": "libz-rs-sys",
+      "version": "0.6.7",
+      "package_url": "https://github.com/trifectatechfoundation/zlib-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/libz-rs-sys/0.6.7/download",
+          "sha256": "03dcace986b149f29509af6ca70e6182bccce916b644424ecf484faa8ddc899a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "libz_rs_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "libz_rs_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "rust-allocator",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "zlib-rs 0.6.7",
+              "target": "zlib_rs"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.6.7"
+      },
+      "license": "Zlib",
+      "license_ids": [
+        "Zlib"
+      ],
+      "license_file": "LICENSE"
+    },
     "linux-raw-sys 0.12.1": {
       "name": "linux-raw-sys",
       "version": "0.12.1",
@@ -1663,6 +1717,10 @@
             {
               "id": "libc 0.2.189",
               "target": "libc"
+            },
+            {
+              "id": "libz-rs-sys 0.6.7",
+              "target": "libz_rs_sys"
             },
             {
               "id": "ruzstd 0.9.0",
@@ -3070,14 +3128,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "zlib-rs 0.6.6": {
+    "zlib-rs 0.6.7": {
       "name": "zlib-rs",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "package_url": "https://github.com/trifectatechfoundation/zlib-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/zlib-rs/0.6.6/download",
-          "sha256": "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+          "url": "https://static.crates.io/crates/zlib-rs/0.6.7/download",
+          "sha256": "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
         }
       },
       "targets": [
@@ -3101,13 +3159,14 @@
         ],
         "crate_features": {
           "common": [
+            "__internal-api",
             "rust-allocator",
             "std"
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.6"
+        "version": "0.6.7"
       },
       "license": "Zlib",
       "license_ids": [
@@ -3267,6 +3326,7 @@
     "clap 4.6.4",
     "flate2 1.1.9",
     "libc 0.2.189",
+    "libz-rs-sys 0.6.7",
     "ruzstd 0.9.0",
     "serde 1.0.229",
     "serde_json 1.0.151",

--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -230,6 +230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03dcace986b149f29509af6ca70e6182bccce916b644424ecf484faa8ddc899a"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +268,7 @@ dependencies = [
  "clap",
  "flate2",
  "libc",
+ "libz-rs-sys",
  "ruzstd",
  "serde",
  "serde_json",
@@ -451,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -18,6 +18,9 @@ clap = { version = "4.6.3", features = ["derive"] }
 # miniz_oxide backend and, being pure Rust, keeps the musl builds C free.
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 libc = "0.2.184"
+# The C-shaped face of the zlib-rs crate flate2 already uses; needed for the
+# inflatePrime/inflateSetDictionary checkpoint machinery flate2 does not expose.
+libz-rs-sys = { version = "0.6.6", default-features = false, features = ["std", "rust-allocator"] }
 ruzstd = "0.9.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"

--- a/source/src/cli.rs
+++ b/source/src/cli.rs
@@ -19,6 +19,23 @@ pub struct Cli {
 pub enum Command {
     /// Unpack an image layout into a bundle and run it.
     Run(Box<RunArgs>),
+    /// Build a parallel-decompression checkpoint index for a gzip blob.
+    Index(IndexArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct IndexArgs {
+    /// Gzip layer blob to index.
+    #[arg(long, value_name = "PATH")]
+    pub blob: Utf8PathBuf,
+
+    /// Where to write the index.
+    #[arg(long, value_name = "PATH")]
+    pub output: Utf8PathBuf,
+
+    /// Target uncompressed distance between checkpoints, in bytes.
+    #[arg(long, value_name = "BYTES", default_value_t = 4 << 20)]
+    pub span: u64,
 }
 
 #[derive(Debug, Args)]
@@ -155,6 +172,7 @@ mod tests {
         argv.extend_from_slice(args);
         match Cli::try_parse_from(argv).expect("parse").command {
             Command::Run(args) => *args,
+            other => panic!("expected `run`, parsed {other:?}"),
         }
     }
 

--- a/source/src/launcher.rs
+++ b/source/src/launcher.rs
@@ -129,7 +129,9 @@ mod tests {
             Utf8Path::new("/tmp/rf"),
             &["/bin/echo".to_string(), "--not-a-flag".to_string()],
         );
-        let crate::cli::Command::Run(args) = crate::cli::Cli::parse_from(argv).command;
+        let crate::cli::Command::Run(args) = crate::cli::Cli::parse_from(argv).command else {
+            panic!("synthesised command line must parse as `run`");
+        };
         assert_eq!(args.layout, "/tmp/rf/ws/pkg/image");
         assert_eq!(args.runtime, "/tmp/rf/tools/runc");
         assert!(args.read_only);

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -9,12 +9,13 @@ mod log;
 mod runtime;
 mod spec;
 mod sys;
+mod zinfo;
 
 use camino::Utf8PathBuf;
 use clap::Parser;
 
 use crate::bundle::Bundle;
-use crate::cli::{Cli, Command, RunArgs};
+use crate::cli::{Cli, Command, IndexArgs, RunArgs};
 use crate::error::{Error, Result};
 use crate::extract::RootfsExtractor;
 use crate::image::{Layout, Platform};
@@ -36,6 +37,7 @@ fn main() -> std::process::ExitCode {
         };
         match cli.command {
             Command::Run(args) => run(*args),
+            Command::Index(args) => index(args),
         }
     });
     match code {
@@ -130,6 +132,18 @@ fn run(args: RunArgs) -> Result<i32> {
     runc.delete(&request);
     log!("Container has exited, cleaning up...");
     result
+}
+
+fn index(args: IndexArgs) -> Result<i32> {
+    let blob = std::fs::read(&args.blob)
+        .map_err(|source| Error::io(format!("reading {}", args.blob), source))?;
+    let index = zinfo::Index::build(&blob, args.span)?;
+    let file = std::fs::File::create(&args.output)
+        .map_err(|source| Error::io(format!("creating {}", args.output), source))?;
+    index
+        .write_to(std::io::BufWriter::new(file))
+        .map_err(|source| Error::io(format!("writing {}", args.output), source))?;
+    Ok(0)
 }
 
 fn parse_platform(value: Option<&str>) -> Result<Platform> {

--- a/source/src/zinfo.rs
+++ b/source/src/zinfo.rs
@@ -1,0 +1,544 @@
+//! Checkpoint index for gzip layer blobs, in the spirit of zlib's `zran.c`
+//! and SOCI's zTOC. A checkpoint records enough inflate state (bit offset and
+//! 32 KiB window) to resume decompression at a deflate block boundary, which
+//! lets independent threads inflate disjoint spans of one gzip member.
+//!
+//! Built at Bazel build time by `oci_runtime index`; the image blobs are never
+//! modified. Each span also carries a CRC-32 of its uncompressed bytes: blob
+//! digests only cover the compressed bytes, so a corrupt index would otherwise
+//! corrupt the rootfs silently.
+
+// The resume side is only exercised by tests until the parallel extraction
+// path lands; remove with that change.
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::io::{self, Read, Write};
+
+use crate::error::{Error, Result};
+
+const MAGIC: &[u8; 4] = b"OZI1";
+const WINDOW_SIZE: usize = 32 * 1024;
+/// Checkpoints are only useful while spans decompress in bounded memory.
+const MAX_CHECKPOINTS: u32 = 1 << 20;
+
+/// Resume point at a deflate block boundary (or a gzip member start).
+#[derive(Debug, PartialEq, Eq)]
+pub struct Checkpoint {
+    /// Offset of the first compressed byte not yet consumed at the boundary.
+    pub in_offset: u64,
+    /// Unconsumed high bits of the byte at `in_offset - 1`; 0 when byte aligned.
+    pub bits: u8,
+    /// Uncompressed offset this checkpoint resumes at.
+    pub out_offset: u64,
+    /// Sliding window at the boundary; empty at a stream or member start,
+    /// where inflate instead parses the gzip header.
+    pub window: Vec<u8>,
+    /// CRC-32 of the uncompressed span from here to the next checkpoint.
+    pub crc: u32,
+}
+
+/// A blob's checkpoints, always starting with the stream start, so that the
+/// spans between consecutive checkpoints cover the whole uncompressed output.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Index {
+    pub uncompressed_len: u64,
+    pub checkpoints: Vec<Checkpoint>,
+}
+
+impl Index {
+    /// Decompresses `blob` once, dropping a checkpoint at the first block
+    /// boundary after every `span` uncompressed bytes.
+    pub fn build(blob: &[u8], span: u64) -> Result<Self> {
+        let context = "indexing gzip blob";
+        let mut inflater = Inflater::new(HEADER_WINDOW_BITS).map_err(|e| Error::io(context, e))?;
+        let mut buf = vec![0u8; 1 << 20];
+        let mut checkpoints = vec![Checkpoint {
+            in_offset: 0,
+            bits: 0,
+            out_offset: 0,
+            window: Vec::new(),
+            crc: 0,
+        }];
+        let mut crc = flate2::Crc::new();
+        let mut in_pos: usize = 0;
+        let mut out_pos: u64 = 0;
+        let mut last = 0u64;
+
+        loop {
+            let (consumed, produced, ret) = inflater
+                .inflate(&blob[in_pos..], &mut buf, Flush::Block)
+                .map_err(|e| Error::io(context, e))?;
+            in_pos += consumed;
+            out_pos += produced as u64;
+            crc.update(&buf[..produced]);
+
+            match ret {
+                Z_STREAM_END if in_pos == blob.len() => break,
+                Z_STREAM_END => {
+                    // Another gzip member follows; its start is a checkpoint.
+                    checkpoints.last_mut().expect("non-empty").crc = crc.sum();
+                    crc.reset();
+                    checkpoints.push(Checkpoint {
+                        in_offset: in_pos as u64,
+                        bits: 0,
+                        out_offset: out_pos,
+                        window: Vec::new(),
+                        crc: 0,
+                    });
+                    last = out_pos;
+                    inflater.reset().map_err(|e| Error::io(context, e))?;
+                    continue;
+                }
+                Z_OK if consumed == 0 && produced == 0 => {
+                    return Err(Error::io(
+                        context,
+                        io::Error::other("truncated or corrupt gzip stream"),
+                    ));
+                }
+                Z_OK => {}
+                _ => unreachable!("Inflater::inflate returned {ret}"),
+            }
+
+            // data_type: bits 0..=2 count the unconsumed bits of the last
+            // consumed byte, 128 marks a block boundary, 64 the end of stream.
+            let data_type = inflater.data_type();
+            if data_type & 128 != 0 && data_type & 64 == 0 && out_pos >= last + span {
+                if checkpoints.len() as u32 == MAX_CHECKPOINTS {
+                    return Err(Error::io(context, io::Error::other("too many checkpoints")));
+                }
+                checkpoints.last_mut().expect("non-empty").crc = crc.sum();
+                crc.reset();
+                checkpoints.push(Checkpoint {
+                    in_offset: in_pos as u64,
+                    bits: (data_type & 7) as u8,
+                    out_offset: out_pos,
+                    window: inflater.window().map_err(|e| Error::io(context, e))?,
+                    crc: 0,
+                });
+                last = out_pos;
+            }
+        }
+        checkpoints.last_mut().expect("non-empty").crc = crc.sum();
+
+        Ok(Index {
+            uncompressed_len: out_pos,
+            checkpoints,
+        })
+    }
+
+    /// Inflates the span between checkpoint `i` and its successor (or the end
+    /// of the stream) and verifies it against the recorded CRC.
+    pub fn extract_span(&self, blob: &[u8], i: usize) -> Result<Vec<u8>> {
+        let context = "resuming from checkpoint";
+        let point = &self.checkpoints[i];
+        let end = self
+            .checkpoints
+            .get(i + 1)
+            .map_or(self.uncompressed_len, |next| next.out_offset);
+        let len = (end - point.out_offset) as usize;
+
+        // An empty window is a stream or member start: parse the header there.
+        let at_header = point.window.is_empty() && point.bits == 0;
+        let mut inflater = Inflater::new(if at_header {
+            HEADER_WINDOW_BITS
+        } else {
+            RAW_WINDOW_BITS
+        })
+        .map_err(|e| Error::io(context, e))?;
+        if point.bits != 0 {
+            // The boundary sits inside the previous byte: feed its unconsumed
+            // high bits, then continue from the byte boundary.
+            let byte = blob[point.in_offset as usize - 1];
+            inflater
+                .prime(point.bits, byte >> (8 - point.bits))
+                .map_err(|e| Error::io(context, e))?;
+        }
+        if !point.window.is_empty() {
+            inflater
+                .set_dictionary(&point.window)
+                .map_err(|e| Error::io(context, e))?;
+        }
+
+        let mut out = vec![0u8; len];
+        let mut in_pos = point.in_offset as usize;
+        let mut filled = 0usize;
+        while filled < len {
+            let (consumed, produced, ret) = inflater
+                .inflate(&blob[in_pos..], &mut out[filled..], Flush::None)
+                .map_err(|e| Error::io(context, e))?;
+            in_pos += consumed;
+            filled += produced;
+            match ret {
+                Z_STREAM_END if filled < len => {
+                    // The span continues into the next gzip member.
+                    if in_pos == blob.len() {
+                        return Err(Error::io(
+                            context,
+                            io::Error::other("stream ended before the indexed span"),
+                        ));
+                    }
+                    inflater =
+                        Inflater::new(HEADER_WINDOW_BITS).map_err(|e| Error::io(context, e))?;
+                }
+                Z_OK if consumed == 0 && produced == 0 => {
+                    return Err(Error::io(
+                        context,
+                        io::Error::other("truncated or corrupt gzip stream"),
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        let mut crc = flate2::Crc::new();
+        crc.update(&out);
+        if crc.sum() != point.crc {
+            return Err(Error::io(
+                context,
+                io::Error::other(format!("checkpoint {i} does not match its span checksum")),
+            ));
+        }
+        Ok(out)
+    }
+
+    pub fn write_to(&self, mut writer: impl Write) -> io::Result<()> {
+        writer.write_all(MAGIC)?;
+        writer.write_all(&self.uncompressed_len.to_le_bytes())?;
+        writer.write_all(&(self.checkpoints.len() as u32).to_le_bytes())?;
+        for point in &self.checkpoints {
+            writer.write_all(&point.in_offset.to_le_bytes())?;
+            writer.write_all(&point.out_offset.to_le_bytes())?;
+            writer.write_all(&point.crc.to_le_bytes())?;
+            writer.write_all(&[point.bits])?;
+            let mut encoder =
+                flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(&point.window)?;
+            let compressed = encoder.finish()?;
+            writer.write_all(&(compressed.len() as u32).to_le_bytes())?;
+            writer.write_all(&compressed)?;
+        }
+        Ok(())
+    }
+
+    pub fn read_from(mut reader: impl Read) -> io::Result<Self> {
+        let mut magic = [0u8; 4];
+        reader.read_exact(&mut magic)?;
+        if magic != *MAGIC {
+            return Err(io::Error::other("not a checkpoint index"));
+        }
+        let uncompressed_len = read_u64(&mut reader)?;
+        let count = read_u32(&mut reader)?;
+        if count == 0 || count > MAX_CHECKPOINTS {
+            return Err(io::Error::other("implausible checkpoint count"));
+        }
+        let mut checkpoints = Vec::with_capacity(count as usize);
+        let mut previous = None;
+        for _ in 0..count {
+            let in_offset = read_u64(&mut reader)?;
+            let out_offset = read_u64(&mut reader)?;
+            let crc = read_u32(&mut reader)?;
+            let mut bits = [0u8];
+            reader.read_exact(&mut bits)?;
+            let compressed_len = read_u32(&mut reader)? as usize;
+            let mut window = Vec::with_capacity(WINDOW_SIZE);
+            flate2::read::DeflateDecoder::new(reader.by_ref().take(compressed_len as u64))
+                .take(WINDOW_SIZE as u64 + 1)
+                .read_to_end(&mut window)?;
+            if window.len() > WINDOW_SIZE || bits[0] > 7 {
+                return Err(io::Error::other("malformed checkpoint"));
+            }
+            if previous.is_some_and(|(i, o)| in_offset < i || out_offset < o) {
+                return Err(io::Error::other("checkpoints out of order"));
+            }
+            previous = Some((in_offset, out_offset));
+            checkpoints.push(Checkpoint {
+                in_offset,
+                bits: bits[0],
+                out_offset,
+                window,
+                crc,
+            });
+        }
+        Ok(Index {
+            uncompressed_len,
+            checkpoints,
+        })
+    }
+}
+
+fn read_u64(reader: &mut impl Read) -> io::Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn read_u32(reader: &mut impl Read) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+/// Accept a gzip (or zlib) header before the deflate stream.
+const HEADER_WINDOW_BITS: i32 = 32 + 15;
+/// Raw deflate, for resuming mid-stream.
+const RAW_WINDOW_BITS: i32 = -15;
+
+const Z_OK: i32 = 0;
+const Z_STREAM_END: i32 = 1;
+
+#[repr(i32)]
+#[derive(Clone, Copy)]
+enum Flush {
+    None = 0,
+    /// Return at every deflate block boundary.
+    Block = 5,
+}
+
+/// The one place that talks to libz-rs-sys. flate2 hides exactly the calls
+/// checkpointing needs (`inflatePrime`, `inflate{Set,Get}Dictionary`, Z_BLOCK),
+/// so this drives the same zlib-rs inflate through its C-shaped API.
+struct Inflater(libz_rs_sys::z_stream);
+
+impl Inflater {
+    fn new(window_bits: i32) -> io::Result<Self> {
+        let mut stream = std::mem::MaybeUninit::<libz_rs_sys::z_stream>::zeroed();
+        // SAFETY: `stream` is a zeroed z_stream, which inflateInit2_ accepts
+        // and initialises; version and size describe this build's z_stream.
+        let ret = unsafe {
+            libz_rs_sys::inflateInit2_(
+                stream.as_mut_ptr(),
+                window_bits,
+                libz_rs_sys::zlibVersion(),
+                std::mem::size_of::<libz_rs_sys::z_stream>() as i32,
+            )
+        };
+        if ret != Z_OK {
+            return Err(io::Error::other("initialising inflate failed"));
+        }
+        // SAFETY: inflateInit2_ returned Z_OK, so the stream is initialised.
+        Ok(Inflater(unsafe { stream.assume_init() }))
+    }
+
+    /// Returns (input consumed, output produced, Z_OK or Z_STREAM_END).
+    fn inflate(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        flush: Flush,
+    ) -> io::Result<(usize, usize, i32)> {
+        self.0.next_in = input.as_ptr().cast_mut();
+        self.0.avail_in = input.len().min(u32::MAX as usize) as u32;
+        self.0.next_out = output.as_mut_ptr();
+        self.0.avail_out = output.len().min(u32::MAX as usize) as u32;
+        // SAFETY: the stream is initialised and next_in/avail_in and
+        // next_out/avail_out describe the two slices above.
+        let ret = unsafe { libz_rs_sys::inflate(&mut self.0, flush as i32) };
+        let consumed = input.len().min(u32::MAX as usize) - self.0.avail_in as usize;
+        let produced = output.len().min(u32::MAX as usize) - self.0.avail_out as usize;
+        match ret {
+            Z_OK | Z_STREAM_END => Ok((consumed, produced, ret)),
+            // Z_BUF_ERROR just means no progress was possible; let the caller
+            // decide whether more input exists.
+            -5 => Ok((consumed, produced, Z_OK)),
+            _ => Err(io::Error::other(format!("inflate failed ({ret})"))),
+        }
+    }
+
+    fn data_type(&self) -> i32 {
+        self.0.data_type
+    }
+
+    /// Feeds the sub-byte bits a resumed stream starts inside of.
+    fn prime(&mut self, bits: u8, value: u8) -> io::Result<()> {
+        // SAFETY: the stream is initialised; bits <= 7 by construction.
+        let ret = unsafe { libz_rs_sys::inflatePrime(&mut self.0, bits as i32, value as i32) };
+        if ret != Z_OK {
+            return Err(io::Error::other("inflatePrime failed"));
+        }
+        Ok(())
+    }
+
+    /// Loads a checkpoint window; raw inflate skips the Adler-32 check.
+    fn set_dictionary(&mut self, window: &[u8]) -> io::Result<()> {
+        // SAFETY: the stream is initialised and the pointer/length pair
+        // describes the `window` slice.
+        let ret = unsafe {
+            libz_rs_sys::inflateSetDictionary(&mut self.0, window.as_ptr(), window.len() as u32)
+        };
+        if ret != Z_OK {
+            return Err(io::Error::other("inflateSetDictionary failed"));
+        }
+        Ok(())
+    }
+
+    /// Copies out the current sliding window, unrotated.
+    fn window(&mut self) -> io::Result<Vec<u8>> {
+        let mut window = vec![0u8; WINDOW_SIZE];
+        let mut len: u32 = 0;
+        // SAFETY: the stream is initialised and `window` has the 32 KiB the
+        // dictionary can occupy at most.
+        let ret = unsafe {
+            libz_rs_sys::inflateGetDictionary(&mut self.0, window.as_mut_ptr(), &mut len)
+        };
+        if ret != Z_OK || len as usize > WINDOW_SIZE {
+            return Err(io::Error::other("inflateGetDictionary failed"));
+        }
+        window.truncate(len as usize);
+        Ok(window)
+    }
+
+    /// Rewinds to before the header, for the next gzip member.
+    fn reset(&mut self) -> io::Result<()> {
+        // SAFETY: the stream is initialised.
+        let ret = unsafe { libz_rs_sys::inflateReset(&mut self.0) };
+        if ret != Z_OK {
+            return Err(io::Error::other("inflateReset failed"));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Inflater {
+    fn drop(&mut self) {
+        // SAFETY: the stream is initialised; inflateEnd is the matching free.
+        unsafe { libz_rs_sys::inflateEnd(&mut self.0) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compressible but non-repeating, so deflate emits many dynamic blocks.
+    fn sample_data(len: usize) -> Vec<u8> {
+        let words = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"];
+        let mut out = Vec::with_capacity(len + 16);
+        let mut state: u64 = 0x2545F4914F6CDD1D;
+        while out.len() < len {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            out.extend_from_slice(words[(state >> 33) as usize % words.len()].as_bytes());
+            out.extend_from_slice(state.to_le_bytes()[..3].as_ref());
+        }
+        out.truncate(len);
+        out
+    }
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn assert_spans_reproduce(index: &Index, blob: &[u8], data: &[u8]) {
+        assert_eq!(index.uncompressed_len, data.len() as u64);
+        let mut reassembled = Vec::new();
+        for i in 0..index.checkpoints.len() {
+            reassembled.extend_from_slice(&index.extract_span(blob, i).unwrap());
+        }
+        assert_eq!(reassembled, data);
+    }
+
+    #[test]
+    fn every_span_resumes_to_the_reference_bytes() {
+        let data = sample_data(2 << 20);
+        let blob = gzip(&data);
+        let index = Index::build(&blob, 128 << 10).unwrap();
+        assert!(
+            index.checkpoints.len() > 4,
+            "expected several checkpoints, found {}",
+            index.checkpoints.len()
+        );
+        assert!(index.checkpoints[1..].iter().any(|p| p.bits != 0));
+        assert_spans_reproduce(&index, &blob, &data);
+    }
+
+    #[test]
+    fn a_second_gzip_member_gets_its_own_checkpoint() {
+        let first = sample_data(300 << 10);
+        let second = sample_data(200 << 10);
+        let mut blob = gzip(&first);
+        let member_start = blob.len() as u64;
+        blob.extend_from_slice(&gzip(&second));
+        let mut data = first;
+        data.extend_from_slice(&second);
+
+        let index = Index::build(&blob, 100 << 10).unwrap();
+        assert!(
+            index
+                .checkpoints
+                .iter()
+                .any(|p| p.in_offset == member_start && p.window.is_empty() && p.bits == 0),
+            "no checkpoint at the member boundary"
+        );
+        assert_spans_reproduce(&index, &blob, &data);
+    }
+
+    #[test]
+    fn a_blob_smaller_than_a_span_still_round_trips() {
+        let data = b"tiny".to_vec();
+        let blob = gzip(&data);
+        let index = Index::build(&blob, 4 << 20).unwrap();
+        assert_eq!(index.checkpoints.len(), 1);
+        assert_spans_reproduce(&index, &blob, &data);
+    }
+
+    #[test]
+    fn the_index_survives_serialisation() {
+        let data = sample_data(1 << 20);
+        let blob = gzip(&data);
+        let index = Index::build(&blob, 128 << 10).unwrap();
+        let mut bytes = Vec::new();
+        index.write_to(&mut bytes).unwrap();
+        let read = Index::read_from(&bytes[..]).unwrap();
+        assert_eq!(read, index);
+        assert_spans_reproduce(&read, &blob, &data);
+    }
+
+    #[test]
+    fn a_truncated_blob_is_an_error_not_a_hang() {
+        let blob = gzip(&sample_data(1 << 20));
+        assert!(Index::build(&blob[..blob.len() / 2], 128 << 10).is_err());
+    }
+
+    #[test]
+    fn garbage_input_is_rejected() {
+        assert!(Index::build(&sample_data(4096), 1 << 10).is_err());
+        assert!(Index::read_from(&b"not an index"[..]).is_err());
+    }
+
+    #[test]
+    fn a_tampered_window_is_caught_by_the_span_checksum() {
+        let data = sample_data(1 << 20);
+        let blob = gzip(&data);
+        let mut index = Index::build(&blob, 128 << 10).unwrap();
+        let point = index
+            .checkpoints
+            .iter_mut()
+            .find(|p| !p.window.is_empty())
+            .unwrap();
+        // Any back-reference the resumed span makes then reads wrong history.
+        for byte in &mut point.window {
+            *byte ^= 0xFF;
+        }
+        let i = index
+            .checkpoints
+            .iter()
+            .position(|p| !p.window.is_empty())
+            .unwrap();
+        // The bytes inflate fine; only the checksum can tell they are wrong.
+        let err = index.extract_span(&blob, i).unwrap_err();
+        assert!(err.to_string().contains("checksum"), "got: {err}");
+    }
+
+    #[test]
+    fn out_of_order_checkpoints_are_rejected_on_read() {
+        let data = sample_data(1 << 20);
+        let blob = gzip(&data);
+        let mut index = Index::build(&blob, 128 << 10).unwrap();
+        assert!(index.checkpoints.len() >= 3);
+        index.checkpoints.swap(1, 2);
+        let mut bytes = Vec::new();
+        index.write_to(&mut bytes).unwrap();
+        assert!(Index::read_from(&bytes[..]).is_err());
+    }
+}


### PR DESCRIPTION
A single gzip member cannot be inflated on more than one core, and decompression is the critical path when unpacking a layout. Borrowing the zran.c/SOCI zTOC idea: an `oci_runtime index` subcommand decompresses a blob once at build time and records a checkpoint (bit offset plus 32 KiB window) at the first deflate block boundary after every 4 MiB of output, so independent threads can later inflate disjoint spans of the same member. Image blobs and digests are unchanged; the index is a build-time sidecar.

Resuming uses inflatePrime/inflateSetDictionary, which flate2 does not expose, so the module drives the same zlib-rs inflate flate2 already uses through its C API (libz-rs-sys); the unsafe is confined to one wrapper. Blob digests only cover compressed bytes, so each checkpoint also carries a CRC-32 of its uncompressed span to catch a corrupt index before it corrupts a rootfs.

Measured on the 5-layer 185 MB bench image (16-core box): every span resumes byte-identical to the streamed output, and parallel inflate of the 74 MB layer reaches 3.3x with 4 threads and 6.2x with 8. The index for that layer is 599 KB (0.8%). Wiring the launcher and Bazel rules comes separately.