### PR TITLE
Index gzip layers when building a runc_binary

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -91,7 +91,7 @@ Register a `launcher_toolchain` to use a patched launcher instead.
 <pre>
 load("@rules_oci_runtime//lib:defs.bzl", "runc_binary")
 
-runc_binary(<a href="#runc_binary-name">name</a>, <a href="#runc_binary-data">data</a>, <a href="#runc_binary-env">env</a>, <a href="#runc_binary-hostname">hostname</a>, <a href="#runc_binary-image">image</a>, <a href="#runc_binary-mounts">mounts</a>, <a href="#runc_binary-read_only">read_only</a>, <a href="#runc_binary-workdir">workdir</a>)
+runc_binary(<a href="#runc_binary-name">name</a>, <a href="#runc_binary-data">data</a>, <a href="#runc_binary-env">env</a>, <a href="#runc_binary-hostname">hostname</a>, <a href="#runc_binary-image">image</a>, <a href="#runc_binary-index">index</a>, <a href="#runc_binary-mounts">mounts</a>, <a href="#runc_binary-read_only">read_only</a>, <a href="#runc_binary-workdir">workdir</a>)
 </pre>
 
 Creates an executable that runs an OCI image with `runc`.
@@ -128,6 +128,7 @@ adding the module is all the setup needed on Linux amd64 and arm64.
 | <a id="runc_binary-env"></a>env |  Environment variables added to the container, overriding the image.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="runc_binary-hostname"></a>hostname |  Hostname inside the container. Defaults to `container`.   | String | optional |  `""`  |
 | <a id="runc_binary-image"></a>image |  An OCI image layout directory, such as an `oci_image` or `oci.pull` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="runc_binary-index"></a>index |  Index the gzip layers at build time so extraction can run in parallel.<br><br>Each checkpoint index is a small sidecar in the runfiles tree; the image layout and its digests are unchanged. Indexing decompresses every layer once per build of the image, so switch it off if build time matters more than startup time.   | Boolean | optional |  `True`  |
 | <a id="runc_binary-mounts"></a>mounts |  Bind mounts, each `SOURCE:DESTINATION[:OPTIONS]`.<br><br>`OPTIONS` is a comma separated mount option list such as `ro` or `rw,noexec`, defaulting to `rw`. `$VAR` and `${VAR}` are expanded in `SOURCE` when the container starts, so `$BUILD_WORKSPACE_DIRECTORY:/src:ro` mounts the workspace.   | List of strings | optional |  `[]`  |
 | <a id="runc_binary-read_only"></a>read_only |  Mount the container root filesystem read-only.   | Boolean | optional |  `False`  |
 | <a id="runc_binary-workdir"></a>workdir |  Working directory inside the container, overriding the image `WorkingDir`.   | String | optional |  `""`  |

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -39,6 +39,7 @@ CASES = [
     "exit_code",
     "hostname_and_hosts",
     "image_env",
+    "layer_indexes",
     "missing_command",
     "read_only_rootfs",
     "rootfs_contents",

--- a/e2e/smoke/cases.sh
+++ b/e2e/smoke/cases.sh
@@ -137,6 +137,38 @@ case_hostname_and_hosts() {
   assert_equals "container" "$output" "default hostname"
 }
 
+case_layer_indexes() {
+  local config="${container}.launch.json"
+  local index_path
+  index_path=$(sed -n 's/.*"index":"\([^"]*\)".*/\1/p' "$config")
+  if [[ -z "$index_path" ]]; then
+    fail "no index entry in $(cat "$config")"
+    return
+  fi
+
+  local index_dir="${runfiles}/${index_path}"
+  local count=0 entry
+  for entry in "$index_dir"/*; do
+    count=$((count + 1))
+    if [[ ! "$(basename "$entry")" =~ ^[0-9a-f]{64}\.zinfo$ ]]; then
+      fail "unexpected index entry ${entry}"
+    fi
+    if [[ ! -s "$entry" ]]; then
+      fail "index ${entry} is empty"
+    fi
+  done
+  if [[ "$count" -eq 0 ]]; then
+    fail "no layer indexes in ${index_dir}"
+  fi
+
+  # The launcher must be told about the sidecar directory.
+  local stderr
+  RULES_OCI_RUNTIME_VERBOSE=1 "$container" /bin/true </dev/null 2>"${TEST_TMPDIR}/index.err" ||
+    fail "container failed"
+  stderr=$(cat "${TEST_TMPDIR}/index.err")
+  assert_contains "$stderr" "Layer indexes available at" "launcher sees the index directory"
+}
+
 case_rootfs_contents() {
   local output
   output=$("$container" /bin/sh -c 'cat /etc/alpine-release; test -L /bin/sh && echo sh-is-a-symlink' </dev/null)

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -4,8 +4,12 @@ load(":toolchains.bzl", "current_launcher")
 package(default_visibility = ["//visibility:private"])
 
 # The launcher for the execution platform, used as the layer indexer in
-# `runc_binary` build actions.
-current_launcher(name = "current_launcher")
+# `runc_binary` build actions. Manual: a bare source checkout has no launcher
+# toolchain, so this must only be built on demand as a `runc_binary` dependency.
+current_launcher(
+    name = "current_launcher",
+    tags = ["manual"],
+)
 
 bzl_library(
     name = "runc_binary",

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -1,6 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":toolchains.bzl", "current_launcher")
 
 package(default_visibility = ["//visibility:private"])
+
+# The launcher for the execution platform, used as the layer indexer in
+# `runc_binary` build actions.
+current_launcher(name = "current_launcher")
 
 bzl_library(
     name = "runc_binary",

--- a/lib/private/runc_binary.bzl
+++ b/lib/private/runc_binary.bzl
@@ -81,14 +81,30 @@ def _runc_binary_impl(ctx):
         is_executable = True,
     )
 
+    content = {
+        "layout": _rlocation_path(ctx, layout),
+        "runtime": _rlocation_path(ctx, runtime_toolchain.binary),
+        "args": args,
+    }
+
+    indexes = []
+    if ctx.attr.index:
+        index_dir = ctx.actions.declare_directory(ctx.label.name + ".zinfo")
+        ctx.actions.run(
+            executable = ctx.attr._indexer[DefaultInfo].files_to_run,
+            arguments = ["index", "--layout", layout.path, "--output", index_dir.path],
+            inputs = [layout],
+            outputs = [index_dir],
+            mnemonic = "OciLayerIndex",
+            progress_message = "Indexing gzip layers of %{label}",
+        )
+        content["index"] = _rlocation_path(ctx, index_dir)
+        indexes.append(index_dir)
+
     config = ctx.actions.declare_file(ctx.label.name + ".launch.json")
     ctx.actions.write(
         output = config,
-        content = json.encode({
-            "layout": _rlocation_path(ctx, layout),
-            "runtime": _rlocation_path(ctx, runtime_toolchain.binary),
-            "args": args,
-        }),
+        content = json.encode(content),
     )
 
     runfiles = ctx.runfiles(files = [
@@ -96,7 +112,7 @@ def _runc_binary_impl(ctx):
         config,
         launcher_toolchain.binary,
         runtime_toolchain.binary,
-    ]).merge_all([
+    ] + indexes).merge_all([
         launcher_toolchain.runfiles,
         runtime_toolchain.runfiles,
         ctx.attr.image[DefaultInfo].default_runfiles,
@@ -105,7 +121,7 @@ def _runc_binary_impl(ctx):
     return [
         DefaultInfo(
             executable = launcher,
-            files = depset([launcher, config]),
+            files = depset([launcher, config] + indexes),
             runfiles = runfiles,
         ),
     ]
@@ -139,9 +155,24 @@ container starts, so `$BUILD_WORKSPACE_DIRECTORY:/src:ro` mounts the workspace.
         "read_only": attr.bool(
             doc = "Mount the container root filesystem read-only.",
         ),
+        "index": attr.bool(
+            default = True,
+            doc = """Index the gzip layers at build time so extraction can run in parallel.
+
+Each checkpoint index is a small sidecar in the runfiles tree; the image
+layout and its digests are unchanged. Indexing decompresses every layer once
+per build of the image, so switch it off if build time matters more than
+startup time.
+""",
+        ),
         "data": attr.label_list(
             allow_files = True,
             doc = "Extra files to make available in the runfiles tree, for use with `mounts`.",
+        ),
+        "_indexer": attr.label(
+            default = ":current_launcher",
+            executable = True,
+            cfg = "exec",
         ),
     },
     toolchains = [

--- a/lib/private/toolchains.bzl
+++ b/lib/private/toolchains.bzl
@@ -84,3 +84,29 @@ container_runtime_toolchain = rule(
     doc = _CONTAINER_RUNTIME_DOC,
     attrs = {"binary": _binary_attr("The container runtime executable.")},
 )
+
+def _current_launcher_impl(ctx):
+    # type: (ctx) -> list
+    toolchain = ctx.toolchains[LAUNCHER_TOOLCHAIN_TYPE]
+    executable = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.symlink(
+        output = executable,
+        target_file = toolchain.binary,
+        is_executable = True,
+    )
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = toolchain.runfiles,
+        ),
+    ]
+
+# The launcher from the resolved toolchain as an ordinary executable target.
+# Depended on with `cfg = "exec"`, it provides the launcher for the platform
+# running the build, which the target-configured toolchain of `runc_binary`
+# cannot: build actions such as layer indexing need that.
+current_launcher = rule(
+    implementation = _current_launcher_impl,
+    executable = True,
+    toolchains = [LAUNCHER_TOOLCHAIN_TYPE],
+)

--- a/source/src/cli.rs
+++ b/source/src/cli.rs
@@ -19,17 +19,27 @@ pub struct Cli {
 pub enum Command {
     /// Unpack an image layout into a bundle and run it.
     Run(Box<RunArgs>),
-    /// Build a parallel-decompression checkpoint index for a gzip blob.
+    /// Build parallel-decompression checkpoint indexes for gzip blobs.
     Index(IndexArgs),
 }
 
 #[derive(Debug, Args)]
 pub struct IndexArgs {
     /// Gzip layer blob to index.
-    #[arg(long, value_name = "PATH")]
-    pub blob: Utf8PathBuf,
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "layout",
+        required_unless_present = "layout"
+    )]
+    pub blob: Option<Utf8PathBuf>,
 
-    /// Where to write the index.
+    /// Image layout whose gzip layers are all indexed, across every platform.
+    #[arg(long, value_name = "DIR")]
+    pub layout: Option<Utf8PathBuf>,
+
+    /// Index file to write for `--blob`, or a directory of `<hex>.zinfo`
+    /// files for `--layout`.
     #[arg(long, value_name = "PATH")]
     pub output: Utf8PathBuf,
 
@@ -47,6 +57,10 @@ pub struct RunArgs {
     /// Path to the OCI runtime binary (runc).
     #[arg(long, value_name = "PATH")]
     pub runtime: Utf8PathBuf,
+
+    /// Directory of layer decompression indexes, one `<hex>.zinfo` per gzip layer.
+    #[arg(long, value_name = "DIR")]
+    pub index: Option<Utf8PathBuf>,
 
     /// Additional environment variables, overriding the image.
     #[arg(long = "env", short = 'e', value_name = "NAME=VALUE")]
@@ -201,6 +215,30 @@ mod tests {
         let args = parse(&["--env", "A=1", "-e", "B=2", "--mount", "/a:/b", "-v", "/c:/d:ro"]);
         assert_eq!(args.env, vec!["A=1", "B=2"]);
         assert_eq!(args.mounts, vec!["/a:/b", "/c:/d:ro"]);
+    }
+
+    #[test]
+    fn index_takes_a_blob_or_a_layout_but_not_both() {
+        let blob = ["oci_runtime", "index", "--blob", "/b", "--output", "/o"];
+        assert!(Cli::try_parse_from(blob).is_ok());
+
+        let layout = ["oci_runtime", "index", "--layout", "/l", "--output", "/o"];
+        assert!(Cli::try_parse_from(layout).is_ok());
+
+        let neither = ["oci_runtime", "index", "--output", "/o"];
+        assert!(Cli::try_parse_from(neither).is_err());
+
+        let both = [
+            "oci_runtime",
+            "index",
+            "--blob",
+            "/b",
+            "--layout",
+            "/l",
+            "--output",
+            "/o",
+        ];
+        assert!(Cli::try_parse_from(both).is_err());
     }
 
     #[test]

--- a/source/src/image.rs
+++ b/source/src/image.rs
@@ -233,6 +233,42 @@ impl Layout {
             .json_context(|| format!("parsing manifest {}", descriptor.digest))
     }
 
+    /// Every manifest reachable from `index.json`, regardless of platform.
+    pub fn all_manifests(&self) -> Result<Vec<Manifest>> {
+        let mut queue = vec![self.read_index()?.manifests];
+        let mut manifests = Vec::new();
+        let mut depth = 0usize;
+
+        while let Some(descriptors) = queue.pop() {
+            depth += 1;
+            if depth > 8 {
+                return Err(Error::Layout("image index nested too deeply".to_string()));
+            }
+            for descriptor in descriptors {
+                match descriptor.media_type.as_str() {
+                    MEDIA_TYPE_OCI_INDEX | MEDIA_TYPE_DOCKER_LIST => {
+                        let bytes = self.read_metadata_blob(&descriptor)?;
+                        let index: Index = serde_json::from_slice(&bytes)
+                            .json_context(|| format!("parsing index {}", descriptor.digest))?;
+                        queue.push(index.manifests);
+                    }
+                    MEDIA_TYPE_OCI_MANIFEST | MEDIA_TYPE_DOCKER_MANIFEST | "" => {
+                        let bytes = self.read_metadata_blob(&descriptor)?;
+                        manifests.push(
+                            serde_json::from_slice(&bytes).json_context(|| {
+                                format!("parsing manifest {}", descriptor.digest)
+                            })?,
+                        );
+                    }
+                    other => {
+                        crate::log::log!("ignoring descriptor with media type {other}");
+                    }
+                }
+            }
+        }
+        Ok(manifests)
+    }
+
     fn resolve_manifest_descriptor(&self, platform: &Platform) -> Result<Descriptor> {
         let mut queue = vec![self.read_index()?.manifests];
         let mut available = Vec::new();

--- a/source/src/launcher.rs
+++ b/source/src/launcher.rs
@@ -16,6 +16,8 @@ struct Config {
     layout: String,
     runtime: String,
     #[serde(default)]
+    index: Option<String>,
+    #[serde(default)]
     args: Vec<String>,
 }
 
@@ -72,6 +74,10 @@ impl Config {
             "--runtime".to_string(),
             runfiles.join(&self.runtime).into_string(),
         ];
+        if let Some(index) = &self.index {
+            argv.push("--index".to_string());
+            argv.push(runfiles.join(index).into_string());
+        }
         argv.extend(self.args.iter().cloned());
         argv.extend(user.iter().cloned());
         argv
@@ -110,6 +116,19 @@ mod tests {
                 "/tmp/rf/tools/runc",
                 "--read-only",
             ]
+        );
+    }
+
+    #[test]
+    fn an_index_directory_is_resolved_and_passed_through() {
+        let config: Config = serde_json::from_str(
+            r#"{"layout": "l", "runtime": "r", "index": "ws/pkg/container.zinfo"}"#,
+        )
+        .expect("config");
+        let argv = config.command_line("launcher", Utf8Path::new("/tmp/rf"), &[]);
+        assert_eq!(
+            &argv[argv.len() - 2..],
+            ["--index", "/tmp/rf/ws/pkg/container.zinfo"]
         );
     }
 

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -11,7 +11,7 @@ mod spec;
 mod sys;
 mod zinfo;
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 
 use crate::bundle::Bundle;
@@ -57,6 +57,10 @@ fn run(args: RunArgs) -> Result<i32> {
     log!("Reading image {} for {platform}", layout.root());
 
     let manifest = layout.resolve_manifest(&platform)?;
+    if let Some(index) = &args.index {
+        // Read by the parallel extraction path once it lands.
+        log!("Layer indexes available at {index}");
+    }
     let image_config = layout.read_image_config(&manifest)?;
     if let Some(user) = image_config.user.as_deref()
         && !matches!(user, "" | "0" | "root" | "0:0" | "root:root")
@@ -135,15 +139,47 @@ fn run(args: RunArgs) -> Result<i32> {
 }
 
 fn index(args: IndexArgs) -> Result<i32> {
-    let blob = std::fs::read(&args.blob)
-        .map_err(|source| Error::io(format!("reading {}", args.blob), source))?;
-    let index = zinfo::Index::build(&blob, args.span)?;
-    let file = std::fs::File::create(&args.output)
-        .map_err(|source| Error::io(format!("creating {}", args.output), source))?;
+    if let Some(blob) = &args.blob {
+        index_blob(blob, &args.output, args.span)?;
+    } else if let Some(layout) = &args.layout {
+        index_layout(layout, &args.output, args.span)?;
+    }
+    Ok(0)
+}
+
+fn index_blob(blob: &Utf8Path, output: &Utf8Path, span: u64) -> Result<()> {
+    let bytes =
+        std::fs::read(blob).map_err(|source| Error::io(format!("reading {blob}"), source))?;
+    let index = zinfo::Index::build(&bytes, span)?;
+    let file = std::fs::File::create(output)
+        .map_err(|source| Error::io(format!("creating {output}"), source))?;
     index
         .write_to(std::io::BufWriter::new(file))
-        .map_err(|source| Error::io(format!("writing {}", args.output), source))?;
-    Ok(0)
+        .map_err(|source| Error::io(format!("writing {output}"), source))
+}
+
+/// Indexes every gzip layer of every manifest in the layout, so a
+/// multi-architecture image gets indexes for whichever platform runs it.
+fn index_layout(layout: &Utf8Path, output: &Utf8Path, span: u64) -> Result<()> {
+    let layout = Layout::open(layout)?;
+    std::fs::create_dir_all(output)
+        .map_err(|source| Error::io(format!("creating {output}"), source))?;
+
+    let mut indexed = std::collections::HashSet::new();
+    for manifest in layout.all_manifests()? {
+        for layer in &manifest.layers {
+            if extract::compression_of(&layer.media_type) != Some(extract::Compression::Gzip) {
+                continue;
+            }
+            let hex = image::parse_digest(&layer.digest)?.hex;
+            if !indexed.insert(hex.clone()) {
+                continue;
+            }
+            let blob = layout.blob_path(&layer.digest)?;
+            index_blob(&blob, &output.join(format!("{hex}.zinfo")), span)?;
+        }
+    }
+    Ok(())
 }
 
 fn parse_platform(value: Option<&str>) -> Result<Platform> {
@@ -198,6 +234,95 @@ mod tests {
                 parse_platform(Some(value)).is_err(),
                 "expected {value:?} to be rejected"
             );
+        }
+    }
+
+    mod indexing {
+        use std::io::Write;
+
+        use sha2::{Digest, Sha256};
+
+        use super::super::*;
+
+        fn scratch(name: &str) -> Utf8PathBuf {
+            let dir = Utf8PathBuf::from(std::env::temp_dir().to_str().expect("utf-8 tmpdir"))
+                .join(format!("oci-runtime-index-{name}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(dir.join("blobs/sha256")).expect("create layout");
+            std::fs::write(dir.join("oci-layout"), "{}").expect("oci-layout");
+            dir
+        }
+
+        /// Stores `bytes` under its digest and returns a descriptor JSON fragment.
+        fn install_blob(root: &Utf8Path, media_type: &str, bytes: &[u8]) -> String {
+            let hex = image::hex_encode(&Sha256::digest(bytes));
+            std::fs::write(root.join("blobs/sha256").join(&hex), bytes).expect("write blob");
+            format!(
+                r#"{{"mediaType": "{media_type}", "digest": "sha256:{hex}", "size": {}}}"#,
+                bytes.len()
+            )
+        }
+
+        fn gzip(bytes: &[u8]) -> Vec<u8> {
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+            encoder.write_all(bytes).expect("compress");
+            encoder.finish().expect("finish")
+        }
+
+        #[test]
+        fn a_layout_gets_one_index_per_gzip_layer() {
+            let root = scratch("layout");
+            let gzip_layer = gzip(b"pretend this is a tar");
+            let gzip_hex = image::hex_encode(&Sha256::digest(&gzip_layer));
+
+            let gzip_descriptor = install_blob(
+                &root,
+                "application/vnd.oci.image.layer.v1.tar+gzip",
+                &gzip_layer,
+            );
+            let plain_descriptor = install_blob(
+                &root,
+                "application/vnd.oci.image.layer.v1.tar",
+                b"uncompressed tar",
+            );
+            let config_descriptor =
+                install_blob(&root, "application/vnd.oci.image.config.v1+json", b"{}");
+            // The gzip layer appears twice, as in a multi-platform image
+            // sharing a base layer: it must be indexed once.
+            let manifest = format!(
+                r#"{{"config": {config_descriptor}, "layers": [{gzip_descriptor}, {plain_descriptor}, {gzip_descriptor}]}}"#,
+            );
+            let manifest_descriptor = install_blob(
+                &root,
+                "application/vnd.oci.image.manifest.v1+json",
+                manifest.as_bytes(),
+            );
+            std::fs::write(
+                root.join("index.json"),
+                format!(r#"{{"manifests": [{manifest_descriptor}]}}"#),
+            )
+            .expect("index.json");
+
+            let output = root.join("indexes");
+            index_layout(&root, &output, 4 << 20).expect("index the layout");
+
+            let entries: Vec<String> = std::fs::read_dir(&output)
+                .expect("read output")
+                .map(|entry| {
+                    entry
+                        .expect("entry")
+                        .file_name()
+                        .into_string()
+                        .expect("utf-8")
+                })
+                .collect();
+            assert_eq!(entries, [format!("{gzip_hex}.zinfo")]);
+
+            let file = std::fs::File::open(output.join(&entries[0])).expect("open index");
+            zinfo::Index::read_from(std::io::BufReader::new(file)).expect("a well-formed index");
+
+            std::fs::remove_dir_all(&root).expect("cleanup");
         }
     }
 }


### PR DESCRIPTION
Each runc_binary now runs the launcher's `index` subcommand over the image layout in a build action, producing a `<name>.zinfo` directory with one checkpoint index per gzip layer, keyed by digest. The directory is recorded in the `.launch.json` sidecar and handed to the launcher as `--index`; for now the launcher only logs it, and the parallel extraction path that consumes it follows in the next PR of this stack. Configs without the field and launchers without the flag both keep working, so an index is a pure add-on.

The action needs a launcher that runs on the build machine, but the launcher toolchain is deliberately target-configured because its binary is staged in runfiles. A new `current_launcher` helper target, depended on under `cfg = "exec"`, resolves the same toolchain for the execution platform instead.

`index --layout` walks every manifest rather than resolving one platform, so a multi-architecture layout gets indexes for whichever platform ends up running it, with layers shared between manifests indexed once. Non-gzip layers are skipped. Indexing decompresses each layer once per image build (the indexes themselves cost under 1% of blob size), so `index = False` opts a target out when build time matters more than startup time.

105 unit tests and 18 e2e cases pass; the new `layer_indexes` case checks the sidecar contents and the `--index` handoff end to end.