### PR TITLE
Forget cache entries in time bound by what is forgotten

### DIFF
--- a/source/src/extract.rs
+++ b/source/src/extract.rs
@@ -118,8 +118,9 @@ impl RootfsExtractor {
                 let dst = fsutil::join_components(root, &whiteout);
                 if self.parents.contains_parent_of(&dst)? {
                     log!("Whiteout: removing /{}", relative_display(root, &dst));
-                    fsutil::remove_any(&dst)?;
-                    self.parents.forget(&dst);
+                    if fsutil::remove_any(&dst)? {
+                        self.parents.forget(&dst);
+                    }
                 }
                 continue;
             }
@@ -164,8 +165,9 @@ impl RootfsExtractor {
                 self.deferred_modes.push((dst.clone(), mode));
                 entry.set_preserve_permissions(false);
             } else {
-                fsutil::remove_any(&dst)?;
-                self.parents.forget(&dst);
+                if fsutil::remove_any(&dst)? {
+                    self.parents.forget(&dst);
+                }
                 entry.set_preserve_permissions(true);
             }
             entry.set_preserve_mtime(true);

--- a/source/src/fsutil.rs
+++ b/source/src/fsutil.rs
@@ -1,6 +1,6 @@
 //! Filesystem helpers shared by extraction and cleanup.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs;
 use std::io;
 use std::os::unix::fs::PermissionsExt;
@@ -80,19 +80,20 @@ fn make_writable_recursive(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Removes a single filesystem object, following no symlinks.
-pub fn remove_any(path: &Path) -> Result<()> {
+/// Removes a single filesystem object, following no symlinks. Returns whether
+/// there was anything to remove.
+pub fn remove_any(path: &Path) -> Result<bool> {
     match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.is_dir() => force_remove_dir_all(path),
+        Ok(metadata) if metadata.is_dir() => force_remove_dir_all(path).map(|()| true),
         Ok(_) => match fs::remove_file(path) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Ok(()) => Ok(true),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
             Err(err) => Err(crate::error::Error::io(
                 format!("removing {}", path.display()),
                 err,
             )),
         },
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
         Err(err) => Err(crate::error::Error::io(
             format!("inspecting {}", path.display()),
             err,
@@ -111,7 +112,7 @@ pub fn remove_any(path: &Path) -> Result<()> {
 /// nearly all of that into a hash lookup.
 pub struct ParentCache {
     canonical_root: PathBuf,
-    verified: HashSet<PathBuf>,
+    verified: BTreeSet<PathBuf>,
 }
 
 impl ParentCache {
@@ -119,7 +120,7 @@ impl ParentCache {
         let canonical_root = root
             .canonicalize()
             .io_context(|| format!("resolving {}", root.display()))?;
-        let mut verified = HashSet::new();
+        let mut verified = BTreeSet::new();
         verified.insert(root.to_owned());
         verified.insert(canonical_root.clone());
         Ok(ParentCache {
@@ -166,8 +167,21 @@ impl ParentCache {
 
     /// Forgets `path` and everything under it, because what was verified there
     /// has been removed and a later layer may put a symlink in its place.
+    ///
+    /// Paths sort component-wise, so a subtree is a contiguous range and the
+    /// cost is bound by what is actually forgotten, not the cache size: an
+    /// image that replaces thousands of entries would otherwise rescan the
+    /// whole cache for each one.
     pub fn forget(&mut self, path: &Path) {
-        self.verified.retain(|verified| !verified.starts_with(path));
+        let doomed: Vec<PathBuf> = self
+            .verified
+            .range(path.to_path_buf()..)
+            .take_while(|p| p.starts_with(path))
+            .cloned()
+            .collect();
+        for p in &doomed {
+            self.verified.remove(p);
+        }
     }
 }
 


### PR DESCRIPTION
The parent cache sped up the image it was measured on (alpine) and slowed the next one (chromium browserless) down by a factor of five. `forget` rescanned the whole cache with `retain` on every removal, and it ran even when nothing had been removed: replacing a symlink unlinks the old one first, and images built on node or chromium bases carry tens of thousands of symlinks and near as many cached parents. What was measured as a few hundred directories on a distro base became an O(entries x cache) scan.

Two changes, either of which would have hidden the other:

- `remove_any` now reports whether anything was removed, and the cache is only invalidated when something was. A fresh symlink in the first layer no longer pays for an invalidation of nothing.
- The cache is a BTreeSet, where paths sort component-wise and a subtree is a contiguous range, so `forget` walks exactly the entries it drops instead of everything ever verified.

The safety test for the sequence the cache exists to catch (a checked directory replaced by a symlink out of the rootfs) still fails when the invalidation is removed.

On ghcr.io/browserless/chromium v2.34.1 (89,621 entries, 11,926 symlinks, 1.3 GB layout), extracting to disk: 112 s wall / 107 s cpu before, 19 s wall / 13.7 s cpu after, matching the commit before the cache was introduced. The rootfs is identical to that commit's, contents and manifest both. The 185 MB image the cache was measured on keeps its numbers. 94 unit tests and 17 smoke tests pass.

Refs #6.