### PR TITLE
Map layer blobs rather than reading them into the heap

### DIFF
--- a/source/src/extract.rs
+++ b/source/src/extract.rs
@@ -550,23 +550,32 @@ fn inflate_blob(
 /// Runs on the decompression thread when the layer has a checkpoint index:
 /// inflates disjoint spans of the blob on every available core and hands them
 /// to `sender` in order. Spans need random access, so the whole compressed
-/// blob is read up front; hashing it for the digest check then happens over
-/// the same bytes on a thread of its own, instead of alongside the read.
+/// blob is mapped; hashing it for the digest check then happens over the same
+/// pages on a thread of its own, instead of alongside a read.
 fn inflate_indexed(
     mut file: fs::File,
     index: &zinfo::Index,
     descriptor: &Descriptor,
     sender: SyncSender<io::Result<Chunk>>,
 ) -> Result<()> {
-    let capacity = file.metadata().map_or(0, |m| m.len()) as usize;
-    let mut blob = Vec::with_capacity(capacity);
-    if let Err(err) = file.read_to_end(&mut blob) {
+    let len = file.metadata().map_or(0, |m| m.len()) as usize;
+    let mapped = crate::sys::Mapping::of(&file, len);
+    // Nothing to map, or the kernel would not: the spans still need the whole
+    // blob, so fall back to a copy of it.
+    let mut read = Vec::new();
+    if mapped.is_none()
+        && let Err(err) = file.read_to_end(&mut read)
+    {
         let _ = sender.send(Err(io::Error::other(err.to_string())));
         return Err(Error::io(
             format!("reading layer {}", descriptor.digest),
             err,
         ));
     }
+    let blob: &[u8] = match &mapped {
+        Some(mapping) => mapping,
+        None => &read,
+    };
 
     let spans = index.checkpoints.len();
     let workers = thread::available_parallelism()

--- a/source/src/sys.rs
+++ b/source/src/sys.rs
@@ -1,8 +1,9 @@
 //! The small amount of libc this binary needs: identity, tty detection,
-//! randomness and signal forwarding.
+//! randomness, file mapping and signal forwarding.
 
 use std::fs::File;
 use std::io::Read;
+use std::os::fd::AsRawFd;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use crate::error::{IoContext, Result};
@@ -19,6 +20,71 @@ const FORWARDED: [libc::c_int; 7] = [
     libc::SIGUSR2,
     libc::SIGWINCH,
 ];
+
+/// A read-only mapping of a whole file.
+///
+/// Callers that need random access over a blob would otherwise have to copy it
+/// into the heap first; a mapping lets them read the page cache in place, and
+/// lets several threads fault in the pages they touch concurrently.
+///
+/// The bytes are only valid while the file behind them is: truncating it under
+/// a live mapping turns reads past the new end into SIGBUS rather than a short
+/// read. Every caller here maps an immutable content addressed blob.
+pub struct Mapping {
+    ptr: *mut libc::c_void,
+    len: usize,
+}
+
+// SAFETY: the mapping is read-only for its whole life and owns its address
+// range, so handing it between threads exposes nothing thread-affine.
+unsafe impl Send for Mapping {}
+unsafe impl Sync for Mapping {}
+
+impl Mapping {
+    /// Maps `len` bytes of `file`, or returns `None` when there is nothing to
+    /// map or the kernel refuses. Mapping is an optimisation: a caller that
+    /// gets `None` is expected to read the file instead.
+    pub fn of(file: &File, len: usize) -> Option<Self> {
+        if len == 0 {
+            return None;
+        }
+        // SAFETY: a null hint asks the kernel to choose the address, and the
+        // descriptor is open for the duration of the call.
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ,
+                libc::MAP_PRIVATE,
+                file.as_raw_fd(),
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            return None;
+        }
+        Some(Mapping { ptr, len })
+    }
+}
+
+impl std::ops::Deref for Mapping {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        // SAFETY: mmap returned `len` readable bytes at `ptr`, and the mapping
+        // outlives the slice.
+        unsafe { std::slice::from_raw_parts(self.ptr as *const u8, self.len) }
+    }
+}
+
+impl Drop for Mapping {
+    fn drop(&mut self) {
+        // SAFETY: the pointer and length are the ones mmap handed back.
+        unsafe {
+            libc::munmap(self.ptr, self.len);
+        }
+    }
+}
 
 pub fn euid() -> u32 {
     // SAFETY: geteuid is always successful and has no preconditions.


### PR DESCRIPTION
Spans need random access to the compressed blob, so an indexed layer read the whole thing before any of its spans could start. Nothing else runs during that read: the workers have no bytes to inflate and the writer has no entries to write, so every layer began with a stall the length of a 74 MiB copy.

Mapping the blob removes both the copy and the stall. The workers fault in the pages they touch, concurrently, as they reach them. A file the kernel will not map falls back to reading it, since mapping is only ever an optimisation here.

`MADV_WILLNEED` was tried and is worse than no advice at all (wall 0.715 s against 0.680 s), because it serialises up front exactly the faulting the workers would otherwise spread across themselves.

The blob is no longer copied into the heap, so anonymous memory falls; peak resident size rises, because the mapped pages are counted while they are resident and the decompressors now run further ahead. Those pages are page cache the kernel can drop, which the copy was not.

Measured on a 185 MiB / 9,488 entry image (535 MiB extracted), release builds, min of 8 interleaved rounds, extracted trees verified identical:

```
tmpfs, indexed, musl      wall 1.031 -> 0.896 s   cpu 5.105 -> 4.744 s
tmpfs, indexed, glibc     wall 0.984 -> 0.819 s   cpu 5.523 -> 5.310 s
overlayfs, indexed, musl  wall 1.428 -> 1.299 s   cpu 4.886 -> 4.748 s

peak rss 244 -> 265 MiB, of which anonymous 242 -> 205 MiB
```