### PR TITLE
Build entry destinations without a component list

### DIFF
--- a/source/src/extract.rs
+++ b/source/src/extract.rs
@@ -188,31 +188,40 @@ impl RootfsExtractor {
         // One buffer for the whole layer: allocating per file would cost more
         // than the copy it serves.
         let mut buffer = vec![0u8; CHUNK_BYTES];
+        // Reused for every entry, so a layer costs two path allocations rather
+        // than a handful per entry.
+        let mut path = PathBuf::new();
+        let mut dst = PathBuf::new();
 
         for entry in entries {
             let mut entry = entry.io_context(|| format!("reading layer {layer}"))?;
-            let path = entry
-                .path()
-                .io_context(|| format!("reading entry path in layer {layer}"))?
-                .into_owned();
+            path.clear();
+            path.push(
+                entry
+                    .path()
+                    .io_context(|| format!("reading entry path in layer {layer}"))?
+                    .as_ref(),
+            );
 
-            let Some(parts) = fsutil::sanitize_relative_path(&path) else {
+            if !fsutil::resolve_under(root, &path, &mut dst) {
                 return Err(Error::UnsafeEntry {
                     layer: layer.to_string(),
                     path: path.display().to_string(),
                 });
-            };
+            }
 
-            let name = parts.last().map(|p| p.to_string_lossy().into_owned()).unwrap_or_default();
-            if name == OPAQUE_WHITEOUT {
-                let dir = fsutil::join_components(root, &parts[..parts.len() - 1]);
+            let name = dst.file_name().unwrap_or_default().as_bytes();
+            if name == OPAQUE_WHITEOUT.as_bytes() {
+                dst.pop();
+                let dir = std::mem::take(&mut dst);
                 self.apply_opaque_whiteout(root, &dir)?;
+                dst = dir;
                 continue;
             }
-            if let Some(target) = name.strip_prefix(WHITEOUT_PREFIX) {
-                let mut whiteout = parts[..parts.len() - 1].to_vec();
-                whiteout.push(target.into());
-                let dst = fsutil::join_components(root, &whiteout);
+            if let Some(target) = name.strip_prefix(WHITEOUT_PREFIX.as_bytes()) {
+                // `target` borrows the buffer the new name has to go into.
+                let target = std::ffi::OsStr::from_bytes(target).to_owned();
+                dst.set_file_name(target);
                 if self.parents.contains_parent_of(&dst)? {
                     log!("Whiteout: removing /{}", relative_display(root, &dst));
                     if fsutil::remove_any(&dst)? {
@@ -222,7 +231,6 @@ impl RootfsExtractor {
                 continue;
             }
 
-            let dst = fsutil::join_components(root, &parts);
             let entry_type = entry.header().entry_type();
             if !is_supported(entry_type) {
                 warning!(
@@ -297,9 +305,10 @@ impl RootfsExtractor {
                     let target = link_name(&entry, layer)?.ok_or_else(unsafe_entry)?;
                     // A hard link names an earlier entry of the same archive,
                     // so it is rooted at the rootfs like any other entry path.
-                    let source = fsutil::sanitize_relative_path(&target)
-                        .map(|parts| fsutil::join_components(root, &parts))
-                        .ok_or_else(unsafe_entry)?;
+                    let mut source = PathBuf::new();
+                    if !fsutil::resolve_under(root, &target, &mut source) {
+                        return Err(unsafe_entry());
+                    }
                     if !self.parents.contains_parent_of(&source)? {
                         return Err(unsafe_entry());
                     }

--- a/source/src/fsutil.rs
+++ b/source/src/fsutil.rs
@@ -8,24 +8,32 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::error::{IoContext, Result};
 
-/// Splits a tar entry path into safe components, or returns `None` when the
-/// entry tries to escape (absolute paths are rooted at the rootfs, `..` is
-/// never allowed).
-pub fn sanitize_relative_path(path: &Path) -> Option<Vec<std::ffi::OsString>> {
-    let mut parts = Vec::new();
+/// Rebuilds `dst` as `root` joined with the safe components of `path`, or
+/// returns false when the entry tries to escape (absolute paths are rooted at
+/// the rootfs, `..` is never allowed) or names nothing at all.
+///
+/// The destination is what every caller actually wants, so it is built
+/// directly into a buffer they own: a layer is tens of thousands of entries,
+/// and a component list per entry is tens of thousands of allocations that
+/// only exist to be joined back together.
+pub fn resolve_under(root: &Path, path: &Path, dst: &mut PathBuf) -> bool {
+    dst.clear();
+    dst.push(root);
+    let mut components = 0;
     for component in path.components() {
         match component {
             Component::Prefix(_) | Component::RootDir | Component::CurDir => continue,
-            Component::ParentDir => return None,
+            Component::ParentDir => return false,
             Component::Normal(part) => {
                 if part.is_empty() {
                     continue;
                 }
-                parts.push(part.to_owned())
+                dst.push(part);
+                components += 1;
             }
         }
     }
-    if parts.is_empty() { None } else { Some(parts) }
+    components > 0
 }
 
 /// Removes a tree even when directories were extracted without write permission.
@@ -269,60 +277,61 @@ fn parent_is_within(canonical_root: &Path, path: &Path) -> Result<bool> {
     Ok(canonical_parent.starts_with(canonical_root))
 }
 
-pub fn join_components(root: &Path, parts: &[std::ffi::OsString]) -> PathBuf {
-    let mut path = root.to_path_buf();
-    for part in parts {
-        path.push(part);
-    }
-    path
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
 
-    fn parts(path: &str) -> Option<Vec<String>> {
-        sanitize_relative_path(Path::new(path))
-            .map(|parts| parts.into_iter().map(|p| p.to_string_lossy().into_owned()).collect())
+    fn resolved(path: &str) -> Option<String> {
+        let mut dst = PathBuf::new();
+        resolve_under(Path::new("/tmp/rootfs"), Path::new(path), &mut dst)
+            .then(|| dst.to_string_lossy().into_owned())
     }
 
     #[test]
     fn absolute_paths_are_rooted_at_the_rootfs() {
-        assert_eq!(parts("/etc/passwd"), Some(vec!["etc".into(), "passwd".into()]));
+        assert_eq!(resolved("/etc/passwd").as_deref(), Some("/tmp/rootfs/etc/passwd"));
     }
 
     #[test]
     fn leading_dot_slash_is_stripped() {
-        assert_eq!(parts("./usr/bin/env"), Some(vec!["usr".into(), "bin".into(), "env".into()]));
+        assert_eq!(
+            resolved("./usr/bin/env").as_deref(),
+            Some("/tmp/rootfs/usr/bin/env")
+        );
     }
 
     #[test]
     fn redundant_separators_are_collapsed() {
-        assert_eq!(parts("usr//bin///env"), Some(vec!["usr".into(), "bin".into(), "env".into()]));
+        assert_eq!(
+            resolved("usr//bin///env").as_deref(),
+            Some("/tmp/rootfs/usr/bin/env")
+        );
     }
 
     #[test]
     fn parent_traversal_is_rejected() {
-        assert_eq!(parts("../etc/passwd"), None);
-        assert_eq!(parts("usr/../../etc/passwd"), None);
-        assert_eq!(parts("/../etc"), None);
+        assert_eq!(resolved("../etc/passwd"), None);
+        assert_eq!(resolved("usr/../../etc/passwd"), None);
+        assert_eq!(resolved("/../etc"), None);
     }
 
     #[test]
     fn empty_paths_are_rejected() {
-        assert_eq!(parts("."), None);
-        assert_eq!(parts("/"), None);
-        assert_eq!(parts(""), None);
+        assert_eq!(resolved("."), None);
+        assert_eq!(resolved("/"), None);
+        assert_eq!(resolved(""), None);
     }
 
+    /// The buffer is reused across entries, so a shorter path must not leave a
+    /// longer one's tail behind.
     #[test]
-    fn components_are_joined_in_order() {
-        let joined = join_components(
-            Path::new("/tmp/rootfs"),
-            &[OsString::from("etc"), OsString::from("hosts")],
-        );
-        assert_eq!(joined, PathBuf::from("/tmp/rootfs/etc/hosts"));
+    fn a_reused_buffer_is_rebuilt_rather_than_appended_to() {
+        let root = Path::new("/tmp/rootfs");
+        let mut dst = PathBuf::from("/somewhere/else/entirely");
+        assert!(resolve_under(root, Path::new("usr/bin/env"), &mut dst));
+        assert_eq!(dst, PathBuf::from("/tmp/rootfs/usr/bin/env"));
+        assert!(resolve_under(root, Path::new("etc"), &mut dst));
+        assert_eq!(dst, PathBuf::from("/tmp/rootfs/etc"));
     }
 
     #[test]


### PR DESCRIPTION
Every entry was split into a `Vec<OsString>` of its path components, which was then joined straight back into the destination path, and the last component was copied again into a `String` to test for a whiteout marker. That is around five allocations per entry, and a layer of this image has nine and a half thousand of them.

The component list was never the thing anyone wanted. `resolve_under` now validates and builds the destination in one pass, into a buffer the caller owns and reuses, and the callers read the last component and the parent back off that path instead of keeping a list beside it. Two path allocations per layer rather than five per entry.

The whiteout arms lose nothing: the marker test reads the file name as bytes, and the path a marker names is the same path with its file name replaced.

Measured on a 185 MiB / 9,488 entry image (535 MiB extracted), release musl build, ten interleaved rounds, extracted trees verified identical. Time spent turning entry paths into destinations, across a whole run:

```
min 19.7 -> 5.0 ms, median 51.9 -> 8.1 ms
```

That is a few per cent of an extraction, and end to end it sits close to the noise on tmpfs:

```
tmpfs, indexed, musl   wall 0.723 -> 0.722 s   cpu 3.332 -> 3.514 s
tmpfs, indexed, glibc  wall 0.681 -> 0.645 s   cpu 4.178 -> 4.280 s
```