### PR TITLE
Resolve the image before extracting it

### DIFF
--- a/e2e/smoke/cases.sh
+++ b/e2e/smoke/cases.sh
@@ -147,18 +147,22 @@ case_layer_indexes() {
   fi
 
   local index_dir="${runfiles}/${index_path}"
-  local count=0 entry
+  local checkpoints=0 tables=0 entry
   for entry in "$index_dir"/*; do
-    count=$((count + 1))
-    if [[ ! "$(basename "$entry")" =~ ^[0-9a-f]{64}\.zinfo$ ]]; then
-      fail "unexpected index entry ${entry}"
-    fi
+    case "$(basename "$entry")" in
+      [0-9a-f]*.zinfo) checkpoints=$((checkpoints + 1)) ;;
+      [0-9a-f]*.entries) tables=$((tables + 1)) ;;
+      *) fail "unexpected index entry ${entry}" ;;
+    esac
     if [[ ! -s "$entry" ]]; then
       fail "index ${entry} is empty"
     fi
   done
-  if [[ "$count" -eq 0 ]]; then
+  if [[ "$checkpoints" -eq 0 ]]; then
     fail "no layer indexes in ${index_dir}"
+  fi
+  if [[ "$tables" -ne "$checkpoints" ]]; then
+    fail "expected an entry table per layer index, got ${tables} and ${checkpoints}"
   fi
 
   # The launcher must actually consume the indexes during extraction. It

--- a/source/src/entries.rs
+++ b/source/src/entries.rs
@@ -1,0 +1,374 @@
+//! A record of what a layer's tar stream contains and where.
+//!
+//! The checkpoint index in [`crate::zinfo`] says where to resume inflating a
+//! blob; this says what is worth inflating. Knowing every entry's path and the
+//! offset of its body up front is what lets the whole image be resolved before
+//! anything is written: an entry a later layer overwrites, or a whiteout
+//! removes, never has to be extracted at all.
+//!
+//! Built at Bazel build time alongside the checkpoint index, and read back as
+//! a sidecar next to it. Both are optimisations, so a missing or unreadable
+//! table means falling back to walking the layer, not failing.
+
+use std::io::{self, Read, Write};
+
+use crate::error::{Error, IoContext, Result};
+
+const MAGIC: &[u8; 4] = b"OTE1";
+
+/// A layer with more entries than this is not one we can plan for in bounded
+/// memory, and is far past anything a real image contains.
+const MAX_ENTRIES: u32 = 8 << 20;
+
+/// What an entry asks to be placed. Types the extractor does not support are
+/// recorded rather than dropped, so a plan built from the table can account
+/// for a path the layer mentions even when nothing is written for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    File,
+    Directory,
+    Symlink,
+    HardLink,
+    Unsupported,
+}
+
+impl Kind {
+    fn code(self) -> u8 {
+        match self {
+            Kind::File => 0,
+            Kind::Directory => 1,
+            Kind::Symlink => 2,
+            Kind::HardLink => 3,
+            Kind::Unsupported => 4,
+        }
+    }
+
+    fn from_code(code: u8) -> Option<Self> {
+        Some(match code {
+            0 => Kind::File,
+            1 => Kind::Directory,
+            2 => Kind::Symlink,
+            3 => Kind::HardLink,
+            4 => Kind::Unsupported,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    pub kind: Kind,
+    pub mode: u32,
+    pub mtime: u64,
+    /// Offset of the entry's body in the layer's uncompressed tar stream.
+    pub offset: u64,
+    pub size: u64,
+    /// The path as the layer spells it, before it is rooted at the rootfs.
+    pub path: Vec<u8>,
+    /// Target of a symlink or hard link, empty otherwise.
+    pub link: Vec<u8>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Table {
+    pub entries: Vec<Entry>,
+}
+
+impl Table {
+    /// Walks an uncompressed tar stream and records what it holds.
+    pub fn build(tar: impl Read) -> Result<Self> {
+        let context = "reading a layer's entries";
+        let mut archive = tar::Archive::new(tar);
+        let mut entries = Vec::new();
+        for entry in archive.entries().io_context(|| context.to_string())? {
+            let entry = entry.io_context(|| context.to_string())?;
+            let header = entry.header();
+            let entry_type = header.entry_type();
+            let kind = if entry_type.is_dir() {
+                Kind::Directory
+            } else if entry_type.is_symlink() {
+                Kind::Symlink
+            } else if entry_type.is_hard_link() {
+                Kind::HardLink
+            } else if entry_type.is_file() {
+                Kind::File
+            } else {
+                Kind::Unsupported
+            };
+            if entries.len() as u32 == MAX_ENTRIES {
+                return Err(Error::io(context, io::Error::other("too many entries")));
+            }
+            entries.push(Entry {
+                kind,
+                mode: header.mode().unwrap_or(0o755) & 0o7777,
+                mtime: header.mtime().unwrap_or(0),
+                offset: entry.raw_file_position(),
+                size: entry.size(),
+                path: entry
+                    .path_bytes()
+                    .into_owned(),
+                link: entry
+                    .link_name_bytes()
+                    .map(|link| link.into_owned())
+                    .unwrap_or_default(),
+            });
+        }
+        Ok(Table { entries })
+    }
+
+    /// Paths dominate the table and repeat heavily between entries, so the
+    /// whole of it goes through deflate: seven megabytes of chromium's entries
+    /// become one, and the sidecar ships in a runfiles tree.
+    pub fn write_to(&self, mut writer: impl Write) -> io::Result<()> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&(self.entries.len() as u32).to_le_bytes());
+        for entry in &self.entries {
+            body.push(entry.kind.code());
+            body.extend_from_slice(&entry.mode.to_le_bytes());
+            body.extend_from_slice(&entry.mtime.to_le_bytes());
+            body.extend_from_slice(&entry.offset.to_le_bytes());
+            body.extend_from_slice(&entry.size.to_le_bytes());
+            write_bytes(&mut body, &entry.path)?;
+            write_bytes(&mut body, &entry.link)?;
+        }
+
+        let mut encoder =
+            flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&body)?;
+        let compressed = encoder.finish()?;
+
+        writer.write_all(MAGIC)?;
+        writer.write_all(&(body.len() as u64).to_le_bytes())?;
+        writer.write_all(&(compressed.len() as u64).to_le_bytes())?;
+        writer.write_all(&compressed)
+    }
+
+    pub fn read_from(mut reader: impl Read) -> io::Result<Self> {
+        let mut magic = [0u8; 4];
+        reader.read_exact(&mut magic)?;
+        if magic != *MAGIC {
+            return Err(io::Error::other("not an entry table"));
+        }
+        let plain_len = read_u64(&mut reader)?;
+        let compressed_len = read_u64(&mut reader)?;
+        // The length is what the reader trusts to size its buffer, so it is
+        // checked before anything is allocated from it.
+        if plain_len > (MAX_ENTRIES as u64) * 512 {
+            return Err(io::Error::other("implausible entry table"));
+        }
+        let mut body = Vec::with_capacity(plain_len as usize);
+        flate2::read::DeflateDecoder::new(reader.by_ref().take(compressed_len))
+            .take(plain_len + 1)
+            .read_to_end(&mut body)?;
+        if body.len() as u64 != plain_len {
+            return Err(io::Error::other("truncated entry table"));
+        }
+
+        let mut at = 0;
+        let count = take_u32(&body, &mut at)?;
+        if count > MAX_ENTRIES {
+            return Err(io::Error::other("implausible entry count"));
+        }
+        let mut entries = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            let kind = Kind::from_code(take_u8(&body, &mut at)?)
+                .ok_or_else(|| io::Error::other("unknown entry kind"))?;
+            let mode = take_u32(&body, &mut at)?;
+            let mtime = take_u64(&body, &mut at)?;
+            let offset = take_u64(&body, &mut at)?;
+            let size = take_u64(&body, &mut at)?;
+            let path = take_bytes(&body, &mut at)?;
+            let link = take_bytes(&body, &mut at)?;
+            entries.push(Entry {
+                kind,
+                mode,
+                mtime,
+                offset,
+                size,
+                path,
+                link,
+            });
+        }
+        if at != body.len() {
+            return Err(io::Error::other("trailing bytes in entry table"));
+        }
+        Ok(Table { entries })
+    }
+}
+
+fn write_bytes(out: &mut Vec<u8>, bytes: &[u8]) -> io::Result<()> {
+    let len = u16::try_from(bytes.len())
+        .map_err(|_| io::Error::other("path or link name is too long to record"))?;
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(bytes);
+    Ok(())
+}
+
+fn short(what: &str) -> io::Error {
+    io::Error::other(format!("entry table ends inside {what}"))
+}
+
+fn take_u8(body: &[u8], at: &mut usize) -> io::Result<u8> {
+    let byte = *body.get(*at).ok_or_else(|| short("an entry"))?;
+    *at += 1;
+    Ok(byte)
+}
+
+fn take_u32(body: &[u8], at: &mut usize) -> io::Result<u32> {
+    let bytes = body
+        .get(*at..*at + 4)
+        .ok_or_else(|| short("an entry"))?
+        .try_into()
+        .expect("four bytes");
+    *at += 4;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn take_u64(body: &[u8], at: &mut usize) -> io::Result<u64> {
+    let bytes = body
+        .get(*at..*at + 8)
+        .ok_or_else(|| short("an entry"))?
+        .try_into()
+        .expect("eight bytes");
+    *at += 8;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+fn take_bytes(body: &[u8], at: &mut usize) -> io::Result<Vec<u8>> {
+    let len = {
+        let bytes = body
+            .get(*at..*at + 2)
+            .ok_or_else(|| short("a name"))?
+            .try_into()
+            .expect("two bytes");
+        *at += 2;
+        u16::from_le_bytes(bytes) as usize
+    };
+    let bytes = body.get(*at..*at + len).ok_or_else(|| short("a name"))?;
+    *at += len;
+    Ok(bytes.to_vec())
+}
+
+fn read_u64(reader: &mut impl Read) -> io::Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Directory);
+        header.set_mode(0o755);
+        header.set_size(0);
+        builder
+            .append_data(&mut header, "dir/", io::empty())
+            .expect("dir");
+
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_mtime(1_234_567);
+        header.set_size(5);
+        builder
+            .append_data(&mut header, "dir/file", &b"hello"[..])
+            .expect("file");
+
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        builder
+            .append_link(&mut header, "link", "dir/file")
+            .expect("symlink");
+
+        builder.into_inner().expect("tar")
+    }
+
+    #[test]
+    fn a_table_records_what_the_layer_holds() {
+        let tar = sample();
+        let table = Table::build(&tar[..]).expect("table");
+        let kinds: Vec<Kind> = table.entries.iter().map(|e| e.kind).collect();
+        assert_eq!(
+            kinds,
+            [Kind::Directory, Kind::File, Kind::Symlink],
+            "every entry is recorded, in order"
+        );
+
+        let file = &table.entries[1];
+        assert_eq!(file.path, b"dir/file");
+        assert_eq!(file.size, 5);
+        assert_eq!(file.mode, 0o644);
+        assert_eq!(file.mtime, 1_234_567);
+        assert_eq!(
+            &tar[file.offset as usize..file.offset as usize + 5],
+            b"hello",
+            "the offset names the body in the uncompressed stream"
+        );
+        assert_eq!(table.entries[2].link, b"dir/file");
+    }
+
+    #[test]
+    fn a_table_survives_serialisation() {
+        let table = Table::build(&sample()[..]).expect("table");
+        let mut bytes = Vec::new();
+        table.write_to(&mut bytes).expect("write");
+        assert_eq!(Table::read_from(&bytes[..]).expect("read"), table);
+    }
+
+    #[test]
+    fn an_empty_table_survives_serialisation() {
+        let table = Table::default();
+        let mut bytes = Vec::new();
+        table.write_to(&mut bytes).expect("write");
+        assert_eq!(Table::read_from(&bytes[..]).expect("read"), table);
+    }
+
+    #[test]
+    fn garbage_is_rejected() {
+        assert!(Table::read_from(&b"not a table at all"[..]).is_err());
+
+        let table = Table::build(&sample()[..]).expect("table");
+        let mut bytes = Vec::new();
+        table.write_to(&mut bytes).expect("write");
+
+        // Anything cut inside the header, or inside the deflate stream that
+        // follows it, leaves the reader without a body of the length the
+        // header promised.
+        for truncate_to in [4, 12, 19, bytes.len() / 2] {
+            assert!(
+                Table::read_from(&bytes[..truncate_to]).is_err(),
+                "a table cut to {truncate_to} bytes must be refused"
+            );
+        }
+
+        let mut flipped = bytes.clone();
+        flipped[24] ^= 0xff;
+        assert!(
+            Table::read_from(&flipped[..]).is_err(),
+            "a corrupted deflate stream must be refused"
+        );
+    }
+
+    /// Types the extractor will not place still take part in resolution, so
+    /// they have to be in the table rather than dropped from it.
+    #[test]
+    fn unsupported_types_are_recorded_rather_than_skipped() {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Fifo);
+        header.set_mode(0o644);
+        header.set_size(0);
+        builder.append_data(&mut header, "pipe", io::empty()).expect("fifo");
+        let tar = builder.into_inner().expect("tar");
+
+        let table = Table::build(&tar[..]).expect("table");
+        assert_eq!(table.entries.len(), 1);
+        assert_eq!(table.entries[0].kind, Kind::Unsupported);
+        assert_eq!(table.entries[0].path, b"pipe");
+    }
+}

--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -84,6 +84,14 @@ impl RootfsExtractor {
                 continue;
             }
 
+            // A body a later layer replaces is written and then thrown away,
+            // so the plan takes it out before any of that happens.
+            if matches!(entry_type, EntryType::Regular | EntryType::Continuous)
+                && self.plan.is_shadowed(layer, path.as_os_str().as_bytes())
+            {
+                continue;
+            }
+
             if !self.parents.prepare(&dst)? {
                 return Err(Error::UnsafeEntry {
                     layer: layer.to_string(),

--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -8,6 +8,7 @@
 mod entry;
 mod file;
 mod pipeline;
+mod plan;
 #[cfg(test)]
 mod tests;
 
@@ -37,6 +38,7 @@ pub struct RootfsExtractor {
     index_dir: Option<Utf8PathBuf>,
     deferred_modes: Vec<(PathBuf, u32)>,
     parents: fsutil::ParentCache,
+    plan: plan::Plan,
 }
 
 impl RootfsExtractor {
@@ -47,7 +49,15 @@ impl RootfsExtractor {
             rootfs: rootfs.to_owned(),
             index_dir: index_dir.map(Utf8Path::to_owned),
             deferred_modes: Vec::new(),
+            plan: plan::Plan::default(),
         })
+    }
+
+    /// Resolves the image before extracting it, so that entries a later layer
+    /// replaces are never written. Without an entry table for every layer this
+    /// plans nothing and each layer is placed in full, as before.
+    pub fn plan(&mut self, layers: &[Descriptor]) {
+        self.plan = plan::Plan::build(self.index_dir.as_deref(), layers);
     }
 
     /// Decompression is CPU bound and writing the rootfs is IO bound, so a

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -1,0 +1,319 @@
+//! Deciding what an image's layers actually need to place.
+//!
+//! A path a later layer overwrites, or a whiteout removes, is written and then
+//! thrown away. On a 22 layer image that is most of a gigabyte of writes whose
+//! only lasting effect is to be replaced. The entry tables recorded beside the
+//! checkpoint indexes say what every layer holds, so the whole image can be
+//! resolved before the first byte is written and the doomed entries skipped.
+//!
+//! Skipping is decided on the paths as the layers spell them, while extraction
+//! still resolves those paths against the filesystem it is building. That is
+//! sound in the one direction it is used: if two layers name the same path and
+//! the later one is placed, the earlier one cannot survive. Either both names
+//! resolve to the same file, and the later write replaces it, or something
+//! between them was replaced to make them differ, and that replacement removed
+//! the earlier file anyway.
+//!
+//! It is not sound in the other direction, so nothing here decides *where* an
+//! entry goes, only whether it is worth placing at all.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use camino::Utf8Path;
+
+use crate::entries::{Kind, Table};
+use crate::image::{Descriptor, parse_digest};
+use crate::log::{log, warning};
+
+const WHITEOUT_PREFIX: &[u8] = b".wh.";
+const OPAQUE_WHITEOUT: &[u8] = b".wh..wh..opq";
+
+/// The entries each layer can skip, keyed by layer digest.
+#[derive(Default)]
+pub struct Plan {
+    shadowed: HashMap<String, HashSet<Vec<u8>>>,
+}
+
+impl Plan {
+    /// Resolves the image, or returns an empty plan when it cannot be.
+    ///
+    /// Every layer has to be accounted for: one missing table means unknown
+    /// entries, and an entry that is not known about cannot be shown to be
+    /// safely skippable. Planning is an optimisation, so falling back to
+    /// placing everything is always available.
+    pub fn build(index_dir: Option<&Utf8Path>, layers: &[Descriptor]) -> Plan {
+        let Some(dir) = index_dir else {
+            return Plan::default();
+        };
+        let mut tables = Vec::with_capacity(layers.len());
+        for layer in layers {
+            let Ok(digest) = parse_digest(&layer.digest) else {
+                return Plan::default();
+            };
+            let path = dir.join(format!("{}.entries", digest.hex));
+            let file = match std::fs::File::open(&path) {
+                Ok(file) => file,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Plan::default(),
+                Err(err) => {
+                    warning!("ignoring entry table {path}: {err}");
+                    return Plan::default();
+                }
+            };
+            match Table::read_from(std::io::BufReader::new(file)) {
+                Ok(table) => tables.push(table),
+                Err(err) => {
+                    warning!("ignoring entry table {path}: {err}");
+                    return Plan::default();
+                }
+            }
+        }
+        Plan::resolve(layers, &tables)
+    }
+
+    fn resolve(layers: &[Descriptor], tables: &[Table]) -> Plan {
+        // A hard link is made against what is already on disk, so whatever it
+        // names has to be placed even where a later layer replaces it. There
+        // are single figures of these in a real image.
+        let linked: HashSet<&[u8]> = tables
+            .iter()
+            .flat_map(|table| &table.entries)
+            .filter(|entry| entry.kind == Kind::HardLink)
+            .map(|entry| entry.link.as_slice())
+            .collect();
+
+        // Sorted by path, so everything under a directory is one range and a
+        // whiteout costs what it removes rather than a pass over the image.
+        let mut winner: BTreeMap<&[u8], (usize, usize)> = BTreeMap::new();
+        for (l, table) in tables.iter().enumerate() {
+            for (e, entry) in table.entries.iter().enumerate() {
+                match whiteout(&entry.path) {
+                    Some(Whiteout::Opaque(dir)) => remove_under(&mut winner, &dir),
+                    Some(Whiteout::Named(target)) => {
+                        winner.remove(target.as_slice());
+                        remove_under(&mut winner, &target);
+                    }
+                    None => {
+                        winner.insert(&entry.path, (l, e));
+                    }
+                }
+            }
+        }
+
+        let mut shadowed: HashMap<String, HashSet<Vec<u8>>> = HashMap::new();
+        let mut total = 0;
+        let mut bytes = 0u64;
+        for (l, table) in tables.iter().enumerate() {
+            let mut doomed = HashSet::new();
+            for (e, entry) in table.entries.iter().enumerate() {
+                // Only bodies are worth skipping, and a whiteout marker has to
+                // reach the extractor or nothing gets removed.
+                if entry.kind != Kind::File || whiteout(&entry.path).is_some() {
+                    continue;
+                }
+                if linked.contains(entry.path.as_slice()) {
+                    continue;
+                }
+                if winner.get(entry.path.as_slice()) != Some(&(l, e)) {
+                    bytes += entry.size;
+                    doomed.insert(entry.path.clone());
+                }
+            }
+            total += doomed.len();
+            if !doomed.is_empty() {
+                shadowed.insert(layers[l].digest.clone(), doomed);
+            }
+        }
+        if total > 0 {
+            log!(
+                "Skipping {total} files ({} MiB) that later layers replace",
+                bytes >> 20
+            );
+        }
+        Plan { shadowed }
+    }
+
+    /// True when this layer's copy of `path` is replaced or removed by a later
+    /// one, and so never has to be written.
+    pub fn is_shadowed(&self, digest: &str, path: &[u8]) -> bool {
+        self.shadowed
+            .get(digest)
+            .is_some_and(|doomed| doomed.contains(path))
+    }
+}
+
+enum Whiteout {
+    /// `.wh..wh..opq`: hides everything the lower layers put in this directory.
+    Opaque(Vec<u8>),
+    /// `.wh.name`: hides the one path it names.
+    Named(Vec<u8>),
+}
+
+fn whiteout(path: &[u8]) -> Option<Whiteout> {
+    let (dir, name) = match path.iter().rposition(|&b| b == b'/') {
+        Some(at) => (&path[..at], &path[at + 1..]),
+        None => (&path[..0], path),
+    };
+    if name == OPAQUE_WHITEOUT {
+        return Some(Whiteout::Opaque(dir.to_vec()));
+    }
+    let target = name.strip_prefix(WHITEOUT_PREFIX)?;
+    // `.wh.` with nothing after it names nothing.
+    if target.is_empty() {
+        return None;
+    }
+    // The marker sits in the middle of the path, so what it names has to be
+    // put back together rather than sliced out.
+    let mut named = Vec::with_capacity(dir.len() + 1 + target.len());
+    if !dir.is_empty() {
+        named.extend_from_slice(dir);
+        named.push(b'/');
+    }
+    named.extend_from_slice(target);
+    Some(Whiteout::Named(named))
+}
+
+/// Drops every entry beneath `dir`, without touching a sibling whose name
+/// merely starts the same way.
+fn remove_under(winner: &mut BTreeMap<&[u8], (usize, usize)>, dir: &[u8]) {
+    let mut low = dir.to_vec();
+    low.push(b'/');
+    let mut high = low.clone();
+    // One past every path that continues with a separator.
+    *high.last_mut().expect("a trailing separator") = b'/' + 1;
+    let doomed: Vec<&[u8]> = winner
+        .range::<[u8], _>((
+            std::ops::Bound::Included(low.as_slice()),
+            std::ops::Bound::Excluded(high.as_slice()),
+        ))
+        .map(|(path, _)| *path)
+        .collect();
+    for path in doomed {
+        winner.remove(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entries::Entry;
+
+    fn descriptor(n: u8) -> Descriptor {
+        Descriptor {
+            media_type: "application/vnd.oci.image.layer.v1.tar+gzip".to_string(),
+            digest: format!("sha256:{:064x}", n),
+            size: 0,
+            platform: None,
+        }
+    }
+
+    fn file(path: &str) -> Entry {
+        Entry {
+            kind: Kind::File,
+            mode: 0o644,
+            mtime: 0,
+            offset: 0,
+            size: 1,
+            path: path.as_bytes().to_vec(),
+            link: Vec::new(),
+        }
+    }
+
+    fn table(paths: &[&str]) -> Table {
+        Table {
+            entries: paths.iter().map(|p| file(p)).collect(),
+        }
+    }
+
+    fn plan_of(layers: &[Table]) -> (Plan, Vec<Descriptor>) {
+        let descriptors: Vec<Descriptor> = (0..layers.len() as u8).map(descriptor).collect();
+        (Plan::resolve(&descriptors, layers), descriptors)
+    }
+
+    #[test]
+    fn a_later_layer_shadows_an_earlier_copy() {
+        let (plan, d) = plan_of(&[table(&["a", "keep"]), table(&["a"])]);
+        assert!(plan.is_shadowed(&d[0].digest, b"a"));
+        assert!(!plan.is_shadowed(&d[0].digest, b"keep"));
+        assert!(!plan.is_shadowed(&d[1].digest, b"a"), "the winner stays");
+    }
+
+    #[test]
+    fn a_whiteout_shadows_what_it_hides() {
+        let (plan, d) = plan_of(&[table(&["dir/a", "dir/b", "other"]), table(&["dir/.wh.a"])]);
+        assert!(plan.is_shadowed(&d[0].digest, b"dir/a"));
+        assert!(!plan.is_shadowed(&d[0].digest, b"dir/b"));
+        assert!(!plan.is_shadowed(&d[0].digest, b"other"));
+    }
+
+    /// The marker is itself a regular file entry, and the extractor has to see
+    /// it or nothing is removed from the tree the lower layers built.
+    #[test]
+    fn a_whiteout_marker_is_never_shadowed() {
+        let (plan, d) = plan_of(&[table(&["dir/.wh.a"]), table(&["dir/.wh.a"])]);
+        assert!(!plan.is_shadowed(&d[0].digest, b"dir/.wh.a"));
+        assert!(!plan.is_shadowed(&d[1].digest, b"dir/.wh.a"));
+    }
+
+    #[test]
+    fn an_opaque_whiteout_shadows_the_directory_it_names() {
+        let (plan, d) = plan_of(&[
+            table(&["dir/a", "dir/sub/b", "dirty", "elsewhere"]),
+            table(&["dir/.wh..wh..opq"]),
+        ]);
+        assert!(plan.is_shadowed(&d[0].digest, b"dir/a"));
+        assert!(plan.is_shadowed(&d[0].digest, b"dir/sub/b"));
+        assert!(
+            !plan.is_shadowed(&d[0].digest, b"dirty"),
+            "a sibling that merely starts the same way is not underneath it"
+        );
+        assert!(!plan.is_shadowed(&d[0].digest, b"elsewhere"));
+    }
+
+    #[test]
+    fn a_whiteout_of_a_directory_shadows_what_is_under_it() {
+        let (plan, d) = plan_of(&[table(&["dir/a", "dir", "dirty"]), table(&["\
+.wh.dir"])]);
+        assert!(plan.is_shadowed(&d[0].digest, b"dir/a"));
+        assert!(plan.is_shadowed(&d[0].digest, b"dir"));
+        assert!(!plan.is_shadowed(&d[0].digest, b"dirty"));
+    }
+
+    /// A later layer restoring a path the whiteout removed keeps it.
+    #[test]
+    fn a_path_written_after_a_whiteout_survives() {
+        let (plan, d) = plan_of(&[table(&["a"]), table(&[".wh.a"]), table(&["a"])]);
+        assert!(plan.is_shadowed(&d[0].digest, b"a"));
+        assert!(!plan.is_shadowed(&d[2].digest, b"a"));
+    }
+
+    /// A hard link is made against the tree as it stands, so the copy it names
+    /// has to be there even when a later layer replaces it.
+    #[test]
+    fn a_file_a_hard_link_names_is_never_shadowed() {
+        let mut linking = table(&["link"]);
+        linking.entries[0].kind = Kind::HardLink;
+        linking.entries[0].link = b"target".to_vec();
+
+        let (plan, d) = plan_of(&[table(&["target"]), linking, table(&["target"])]);
+        assert!(
+            !plan.is_shadowed(&d[0].digest, b"target"),
+            "the copy the link was made against has to be placed"
+        );
+    }
+
+    #[test]
+    fn an_absent_table_plans_nothing() {
+        let plan = Plan::build(None, &[descriptor(0)]);
+        assert!(!plan.is_shadowed(&descriptor(0).digest, b"anything"));
+    }
+
+    #[test]
+    fn whiteout_names_are_recognised() {
+        assert!(matches!(whiteout(b"dir/.wh..wh..opq"), Some(Whiteout::Opaque(d)) if d == b"dir"));
+        assert!(matches!(whiteout(b".wh..wh..opq"), Some(Whiteout::Opaque(d)) if d.is_empty()));
+        assert!(matches!(whiteout(b"dir/.wh.name"), Some(Whiteout::Named(n)) if n == b"dir/name"));
+        assert!(matches!(whiteout(b".wh.name"), Some(Whiteout::Named(n)) if n == b"name"));
+        assert!(whiteout(b"dir/name").is_none());
+        assert!(whiteout(b"dir/.wh.").is_none());
+    }
+}

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -1,5 +1,6 @@
 mod bundle;
 mod cli;
+mod entries;
 mod error;
 mod extract;
 mod fsutil;
@@ -82,6 +83,7 @@ fn run(args: RunArgs) -> Result<i32> {
 
     let rootfs = bundle.rootfs();
     let mut extractor = RootfsExtractor::new(&rootfs, args.index.as_deref())?;
+    extractor.plan(&manifest.layers);
     for layer in &manifest.layers {
         extractor.apply_layer(&layout, layer)?;
     }
@@ -140,14 +142,19 @@ fn run(args: RunArgs) -> Result<i32> {
 
 fn index(args: IndexArgs) -> Result<i32> {
     if let Some(blob) = &args.blob {
-        index_blob(blob, &args.output, args.span)?;
+        index_blob(
+            blob,
+            &args.output,
+            &Utf8PathBuf::from(format!("{}.entries", args.output)),
+            args.span,
+        )?;
     } else if let Some(layout) = &args.layout {
         index_layout(layout, &args.output, args.span)?;
     }
     Ok(0)
 }
 
-fn index_blob(blob: &Utf8Path, output: &Utf8Path, span: u64) -> Result<()> {
+fn index_blob(blob: &Utf8Path, checkpoints: &Utf8Path, entries: &Utf8Path, span: u64) -> Result<()> {
     let file =
         std::fs::File::open(blob).map_err(|source| Error::io(format!("opening {blob}"), source))?;
     let len = file.metadata().map_or(0, |m| m.len()) as usize;
@@ -161,17 +168,39 @@ fn index_blob(blob: &Utf8Path, output: &Utf8Path, span: u64) -> Result<()> {
         Some(mapping) => mapping,
         None => &read,
     };
-    let index = zinfo::Index::build(bytes, span).map_err(|source| match source {
-        // Which blob failed matters more than usual here: this runs as a build
-        // action over every layer of an image at once.
+    // Which blob failed matters more than usual here: this runs as a build
+    // action over every layer of an image at once.
+    let named = |source| match source {
         Error::Io { context, source } => Error::io(format!("{context} {blob}"), source),
         other => other,
-    })?;
-    let file = std::fs::File::create(output)
-        .map_err(|source| Error::io(format!("creating {output}"), source))?;
-    index
-        .write_to(std::io::BufWriter::new(file))
-        .map_err(|source| Error::io(format!("writing {output}"), source))
+    };
+
+    let index = zinfo::Index::build(bytes, span).map_err(named)?;
+    write_sidecar(checkpoints, |writer| index.write_to(writer))?;
+
+    // A second pass rather than a second job for the inflater: the entry walk
+    // wants the tar stream in order, and the checkpoint pass keeps none of it.
+    //
+    // A layer the walk cannot follow still extracts, because extraction reads
+    // the stream itself; it just does not get planned. So the table is left
+    // out rather than failing the build over it.
+    match entries::Table::build(flate2::read::MultiGzDecoder::new(bytes)) {
+        Ok(table) => write_sidecar(entries, |writer| table.write_to(writer)),
+        Err(err) => {
+            log::warn(format!("not recording the entries of {blob}: {err}"));
+            Ok(())
+        }
+    }
+}
+
+fn write_sidecar(
+    path: &Utf8Path,
+    write: impl FnOnce(std::io::BufWriter<std::fs::File>) -> std::io::Result<()>,
+) -> Result<()> {
+    let file = std::fs::File::create(path)
+        .map_err(|source| Error::io(format!("creating {path}"), source))?;
+    write(std::io::BufWriter::new(file))
+        .map_err(|source| Error::io(format!("writing {path}"), source))
 }
 
 /// Indexes every gzip layer of every manifest in the layout, so a
@@ -197,7 +226,11 @@ fn index_layout(layout: &Utf8Path, output: &Utf8Path, span: u64) -> Result<()> {
                 continue;
             }
             let blob = layout.blob_path(&layer.digest)?;
-            work.push((blob, output.join(format!("{hex}.zinfo"))));
+            work.push((
+                blob,
+                output.join(format!("{hex}.zinfo")),
+                output.join(format!("{hex}.entries")),
+            ));
         }
     }
 
@@ -217,8 +250,8 @@ fn index_layout(layout: &Utf8Path, output: &Utf8Path, span: u64) -> Result<()> {
             scope.spawn(move || {
                 loop {
                     let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    let Some((blob, output)) = work.get(i) else { break };
-                    let result = index_blob(blob, output, span);
+                    let Some((blob, checkpoints, entries)) = work.get(i) else { break };
+                    let result = index_blob(blob, checkpoints, entries, span);
                     *results[i].lock().expect("index result") = Some(result);
                 }
             });


### PR DESCRIPTION
A layer that replaces a path an earlier layer shipped makes the earlier write pointless, and a whiteout does the same to everything beneath it. Nothing knew that until the bytes had already been written, because the only record of what a layer holds was the layer itself.

`oci_runtime index` now records an entry table beside each checkpoint index: every entry's kind, mode, mtime, size and the offset of its body in the uncompressed stream. Extraction reads all of them up front, resolves the image, and skips the bodies that cannot survive.

Skipping is decided on the paths the layers spell, while extraction still resolves those against the filesystem it is building. That holds in the one direction it is used: if two layers name the same path and the later one is placed, the earlier cannot survive, because either both names resolve to the same file or something between them was replaced to make them differ, and that replacement removed the earlier file anyway. It does not hold in reverse, so nothing here decides where an entry goes, only whether placing it is worth anything.

Two things must not be skipped. A whiteout marker is itself a regular file entry and has to reach the extractor or nothing is removed. And a hard link is made against the tree as it stands, so whatever it names stays, even where a later layer replaces it: chromium ships one in layer 8 whose target layer 16 whiteouts, and skipping it left the link with nothing to point at.

Tables are deflated, since paths repeat heavily between entries: seven megabytes of chromium's entries become one.

Measured on ghcr.io/browserless/chromium (22 layers, 1015 MiB compressed, 73,164 entries, 209 whiteouts), release musl, min of four interleaved rounds, extracted tree byte for byte identical:

```
wall 2.989 -> 2.535 s   cpu 12.619 -> 11.549 s
17,755 files and 322 MiB of writes no longer happen
```

An image whose layers do not overlap has nothing to skip and is unchanged (0.558 s against 0.546 s). Indexing costs a second pass over each layer to walk its entries: 1.77 s -> 3.22 s for chromium, in a build action that already existed. Sidecars grow 8.3 -> 9.3 MiB.