### PR TITLE
Build the directory tree before the layers run

### DIFF
--- a/source/src/entries.rs
+++ b/source/src/entries.rs
@@ -84,13 +84,19 @@ impl Table {
             let entry = entry.io_context(|| context.to_string())?;
             let header = entry.header();
             let entry_type = header.entry_type();
+            // Classified by what the extractor does with it, not by the type
+            // alone: a continuous file is a file, and a sparse one is placed
+            // like a file even though `tar` has to lay out its holes.
             let kind = if entry_type.is_dir() {
                 Kind::Directory
             } else if entry_type.is_symlink() {
                 Kind::Symlink
             } else if entry_type.is_hard_link() {
                 Kind::HardLink
-            } else if entry_type.is_file() {
+            } else if matches!(
+                entry_type,
+                tar::EntryType::Regular | tar::EntryType::Continuous | tar::EntryType::GNUSparse
+            ) {
                 Kind::File
             } else {
                 Kind::Unsupported

--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -92,6 +92,13 @@ impl RootfsExtractor {
                 continue;
             }
 
+            // A resolved image had its directory tree built before any layer
+            // ran, and a directory entry can only ask for one that is already
+            // there.
+            if entry_type.is_dir() && self.plan.is_resolved() {
+                continue;
+            }
+
             if !self.parents.prepare(&dst)? {
                 return Err(Error::UnsafeEntry {
                     layer: layer.to_string(),

--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -14,6 +14,7 @@ mod tests;
 
 use std::fs;
 use std::io;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::sync::mpsc::sync_channel;
@@ -56,8 +57,33 @@ impl RootfsExtractor {
     /// Resolves the image before extracting it, so that entries a later layer
     /// replaces are never written. Without an entry table for every layer this
     /// plans nothing and each layer is placed in full, as before.
-    pub fn plan(&mut self, layers: &[Descriptor]) {
+    ///
+    /// The directories the image ends up with are created here rather than
+    /// discovered a layer at a time, so nothing later has to work out where an
+    /// entry can go.
+    pub fn plan(&mut self, layers: &[Descriptor]) -> Result<()> {
         self.plan = plan::Plan::build(self.index_dir.as_deref(), layers);
+        if !self.plan.is_resolved() {
+            return Ok(());
+        }
+
+        let root = self.rootfs.clone();
+        let mut path = PathBuf::new();
+        for (relative, mode) in self.plan.directories() {
+            path.clear();
+            path.push(root.as_std_path());
+            path.push(std::ffi::OsStr::from_bytes(relative));
+            match fs::create_dir(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(err) => {
+                    return Err(Error::io(format!("creating {}", path.display()), err));
+                }
+            }
+            self.deferred_modes.push((path.clone(), *mode));
+        }
+        log!("Created {} directories", self.plan.directories().len());
+        Ok(())
     }
 
     /// Decompression is CPU bound and writing the rootfs is IO bound, so a

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -28,10 +28,18 @@ use crate::log::{log, warning};
 const WHITEOUT_PREFIX: &[u8] = b".wh.";
 const OPAQUE_WHITEOUT: &[u8] = b".wh..wh..opq";
 
-/// The entries each layer can skip, keyed by layer digest.
+/// What `create_dir` would have given a directory nothing names.
+const DEFAULT_DIRECTORY_MODE: u32 = 0o755;
+
+/// The entries each layer can skip, keyed by layer digest, and the directory
+/// tree they all need.
 #[derive(Default)]
 pub struct Plan {
     shadowed: HashMap<String, HashSet<Vec<u8>>>,
+    directories: Vec<(Vec<u8>, u32)>,
+    /// False when the image could not be resolved, and every layer therefore
+    /// has to be placed in full.
+    resolved: bool,
 }
 
 impl Plan {
@@ -81,23 +89,7 @@ impl Plan {
             .map(|entry| entry.link.as_slice())
             .collect();
 
-        // Sorted by path, so everything under a directory is one range and a
-        // whiteout costs what it removes rather than a pass over the image.
-        let mut winner: BTreeMap<&[u8], (usize, usize)> = BTreeMap::new();
-        for (l, table) in tables.iter().enumerate() {
-            for (e, entry) in table.entries.iter().enumerate() {
-                match whiteout(&entry.path) {
-                    Some(Whiteout::Opaque(dir)) => remove_under(&mut winner, &dir),
-                    Some(Whiteout::Named(target)) => {
-                        winner.remove(target.as_slice());
-                        remove_under(&mut winner, &target);
-                    }
-                    None => {
-                        winner.insert(&entry.path, (l, e));
-                    }
-                }
-            }
-        }
+        let tree = replay(tables);
 
         let mut shadowed: HashMap<String, HashSet<Vec<u8>>> = HashMap::new();
         let mut total = 0;
@@ -113,7 +105,10 @@ impl Plan {
                 if linked.contains(entry.path.as_slice()) {
                     continue;
                 }
-                if winner.get(entry.path.as_slice()) != Some(&(l, e)) {
+                let survives = tree
+                    .get(entry.path.as_slice())
+                    .is_some_and(|node| node.owner == (l, e));
+                if !survives {
                     bytes += entry.size;
                     doomed.insert(entry.path.clone());
                 }
@@ -129,7 +124,22 @@ impl Plan {
                 bytes >> 20
             );
         }
-        Plan { shadowed }
+        Plan {
+            shadowed,
+            directories: directories(&tree),
+            resolved: true,
+        }
+    }
+
+    /// True when the whole image was resolved, so the directory tree below is
+    /// the one it ends up with and the layers need not build it themselves.
+    pub fn is_resolved(&self) -> bool {
+        self.resolved
+    }
+
+    /// The directories the image needs, parents before children.
+    pub fn directories(&self) -> &[(Vec<u8>, u32)] {
+        &self.directories
     }
 
     /// True when this layer's copy of `path` is replaced or removed by a later
@@ -139,6 +149,121 @@ impl Plan {
             .get(digest)
             .is_some_and(|doomed| doomed.contains(path))
     }
+}
+
+/// What the layers leave at a path once all of them have been applied.
+struct Node {
+    kind: Kind,
+    /// The layer and entry that put it there.
+    owner: (usize, usize),
+    mode: u32,
+}
+
+/// Replays every layer in order into the tree they build between them.
+///
+/// This mirrors what the extractor does to the filesystem, entry for entry,
+/// which is what makes the result something the extractor can be held to:
+/// a directory keeps a symlink already standing where it wants to be, and
+/// anything else takes over the path it names and everything underneath it.
+///
+/// Sorted by path, so everything under a directory is one contiguous range and
+/// a removal costs what it removes rather than a pass over the whole image.
+fn replay(tables: &[Table]) -> BTreeMap<&[u8], Node> {
+    let mut tree: BTreeMap<&[u8], Node> = BTreeMap::new();
+    let mut bound = Vec::new();
+    for (l, table) in tables.iter().enumerate() {
+        for (e, entry) in table.entries.iter().enumerate() {
+            match whiteout(&entry.path) {
+                Some(Whiteout::Opaque(dir)) => remove_under(&mut tree, &dir, &mut bound),
+                Some(Whiteout::Named(target)) => {
+                    tree.remove(target.as_slice());
+                    remove_under(&mut tree, &target, &mut bound);
+                }
+                None => {
+                    let node = Node {
+                        kind: entry.kind,
+                        owner: (l, e),
+                        mode: entry.mode,
+                    };
+                    match entry.kind {
+                        // The extractor warns and moves on, leaving the path
+                        // as it found it.
+                        Kind::Unsupported => {}
+                        Kind::Directory => {
+                            // `prepare_directory` keeps a symlink that already
+                            // resolves to a directory, so the layer's own
+                            // directory entry does not take the path back.
+                            let keep = tree
+                                .get(entry.path.as_slice())
+                                .is_some_and(|at| at.kind == Kind::Symlink);
+                            if !keep {
+                                tree.insert(&entry.path, node);
+                            }
+                        }
+                        // Everything else clears the path first, which takes
+                        // the tree underneath it as well.
+                        _ => {
+                            remove_under(&mut tree, &entry.path, &mut bound);
+                            tree.insert(&entry.path, node);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    tree
+}
+
+/// The directories the final tree needs, parents before children.
+///
+/// A path that ends up a symlink is left out however many entries sit under
+/// it: what it points at is where they actually go, and creating a directory
+/// there would displace the link.
+fn directories(tree: &BTreeMap<&[u8], Node>) -> Vec<(Vec<u8>, u32)> {
+    let mut wanted: BTreeMap<&[u8], u32> = BTreeMap::new();
+    for (path, node) in tree {
+        if node.kind == Kind::Directory && !behind_a_link(tree, path) {
+            wanted.insert(path, node.mode);
+        }
+        // Ancestors nothing names still have to exist. `create_dir` would have
+        // made them with the default mode, so they get it here too.
+        for ancestor in ancestors(path) {
+            if tree.contains_key(ancestor)
+                || wanted.contains_key(ancestor)
+                || behind_a_link(tree, ancestor)
+            {
+                continue;
+            }
+            wanted.insert(ancestor, DEFAULT_DIRECTORY_MODE);
+        }
+    }
+    // A `BTreeMap` orders by path, so a parent always precedes what is under
+    // it and the tree can be created in one pass.
+    wanted
+        .into_iter()
+        .map(|(path, mode)| (path.to_vec(), mode))
+        .collect()
+}
+
+/// Every strict ancestor of `path`, shallowest first.
+fn ancestors(path: &[u8]) -> impl Iterator<Item = &[u8]> {
+    path.iter()
+        .enumerate()
+        .filter(|(_, byte)| **byte == b'/')
+        .map(move |(at, _)| &path[..at])
+        .filter(|ancestor| !ancestor.is_empty())
+}
+
+/// True when something that is not a directory stands on the way to `path`.
+///
+/// Whatever that is resolves somewhere else, and it is not created here, so
+/// there would be nothing to create this under. The extractor resolves the
+/// entries that live there against the tree as it builds it, as it always has.
+fn behind_a_link(tree: &BTreeMap<&[u8], Node>, path: &[u8]) -> bool {
+    ancestors(path).any(|ancestor| {
+        tree.get(ancestor)
+            .is_some_and(|node| node.kind != Kind::Directory)
+    })
 }
 
 enum Whiteout {
@@ -174,21 +299,29 @@ fn whiteout(path: &[u8]) -> Option<Whiteout> {
 
 /// Drops every entry beneath `dir`, without touching a sibling whose name
 /// merely starts the same way.
-fn remove_under(winner: &mut BTreeMap<&[u8], (usize, usize)>, dir: &[u8]) {
-    let mut low = dir.to_vec();
-    low.push(b'/');
-    let mut high = low.clone();
-    // One past every path that continues with a separator.
-    *high.last_mut().expect("a trailing separator") = b'/' + 1;
-    let doomed: Vec<&[u8]> = winner
-        .range::<[u8], _>((
-            std::ops::Bound::Included(low.as_slice()),
-            std::ops::Bound::Excluded(high.as_slice()),
-        ))
-        .map(|(path, _)| *path)
-        .collect();
+///
+/// Every entry that is not a directory replays through here, so the bound it
+/// seeks from is built in a buffer the caller keeps rather than a fresh pair
+/// of allocations per path.
+fn remove_under(tree: &mut BTreeMap<&[u8], Node>, dir: &[u8], bound: &mut Vec<u8>) {
+    bound.clear();
+    bound.extend_from_slice(dir);
+    bound.push(b'/');
+
+    // Everything under `dir` sorts from the bound onwards and is contiguous,
+    // so the first path that is not under it ends the range.
+    let mut doomed: Vec<&[u8]> = Vec::new();
+    for (path, _) in tree.range::<[u8], _>((
+        std::ops::Bound::Included(bound.as_slice()),
+        std::ops::Bound::Unbounded,
+    )) {
+        if !path.starts_with(bound) {
+            break;
+        }
+        doomed.push(path);
+    }
     for path in doomed {
-        winner.remove(path);
+        tree.remove(path);
     }
 }
 
@@ -216,6 +349,38 @@ mod tests {
             path: path.as_bytes().to_vec(),
             link: Vec::new(),
         }
+    }
+
+    fn of_kind(path: &str, kind: Kind) -> Entry {
+        Entry {
+            kind,
+            mode: if kind == Kind::Directory { 0o755 } else { 0o644 },
+            ..file(path)
+        }
+    }
+
+    fn dir(path: &str) -> Entry {
+        of_kind(path, Kind::Directory)
+    }
+
+    fn symlink(path: &str, target: &str) -> Entry {
+        Entry {
+            link: target.as_bytes().to_vec(),
+            ..of_kind(path, Kind::Symlink)
+        }
+    }
+
+    fn layer(entries: Vec<Entry>) -> Table {
+        Table { entries }
+    }
+
+    /// The paths the plan would create as directories, for readability.
+    fn dirs_of(layers: &[Table]) -> Vec<String> {
+        let (plan, _) = plan_of(layers);
+        plan.directories()
+            .iter()
+            .map(|(path, _)| String::from_utf8_lossy(path).into_owned())
+            .collect()
     }
 
     fn table(paths: &[&str]) -> Table {
@@ -307,9 +472,127 @@ mod tests {
         assert!(!plan.is_shadowed(&descriptor(0).digest, b"anything"));
     }
 
+    /// Replacing a directory with anything else takes the tree under it away,
+    /// exactly as `remove_any` does during extraction. Without this the plan
+    /// would keep entries that no longer have anywhere to be, and once the
+    /// directory tree is built up front they would be written through whatever
+    /// took the directory's place.
+    mod a_directory_replaced_by_something_else {
+        use super::*;
+
+        #[test]
+        fn a_symlink_takes_the_tree_under_it() {
+            let (plan, d) = plan_of(&[
+                layer(vec![dir("lib"), file("lib/a"), file("lib/sub/b"), file("libre")]),
+                layer(vec![symlink("lib", "usr/lib")]),
+            ]);
+            assert!(plan.is_shadowed(&d[0].digest, b"lib/a"));
+            assert!(plan.is_shadowed(&d[0].digest, b"lib/sub/b"));
+            assert!(
+                !plan.is_shadowed(&d[0].digest, b"libre"),
+                "a sibling that merely starts the same way is untouched"
+            );
+        }
+
+        #[test]
+        fn a_file_takes_the_tree_under_it() {
+            let (plan, d) = plan_of(&[
+                layer(vec![dir("d"), file("d/a")]),
+                layer(vec![file("d")]),
+            ]);
+            assert!(plan.is_shadowed(&d[0].digest, b"d/a"));
+        }
+
+        #[test]
+        fn a_hard_link_takes_the_tree_under_it() {
+            let mut link = of_kind("d", Kind::HardLink);
+            link.link = b"elsewhere".to_vec();
+            let (plan, d) = plan_of(&[
+                layer(vec![dir("d"), file("d/a"), file("elsewhere")]),
+                layer(vec![link]),
+            ]);
+            assert!(plan.is_shadowed(&d[0].digest, b"d/a"));
+        }
+
+        /// The path is gone, so nothing may be created there as a directory.
+        #[test]
+        fn the_replaced_path_is_not_created_as_a_directory() {
+            let dirs = dirs_of(&[
+                layer(vec![dir("lib"), file("lib/a")]),
+                layer(vec![symlink("lib", "usr/lib")]),
+            ]);
+            assert!(
+                !dirs.iter().any(|d| d == "lib"),
+                "a symlink must not be displaced by a directory: {dirs:?}"
+            );
+        }
+
+        /// Restoring the directory afterwards puts everything back in play.
+        #[test]
+        fn a_directory_put_back_afterwards_is_a_directory_again() {
+            let dirs = dirs_of(&[
+                layer(vec![dir("d"), file("d/a")]),
+                layer(vec![file("d")]),
+                layer(vec![dir("d"), file("d/b")]),
+            ]);
+            assert!(dirs.iter().any(|entry| entry == "d"), "{dirs:?}");
+
+            let (plan, digests) = plan_of(&[
+                layer(vec![dir("d"), file("d/a")]),
+                layer(vec![file("d")]),
+                layer(vec![dir("d"), file("d/b")]),
+            ]);
+            assert!(plan.is_shadowed(&digests[0].digest, b"d/a"));
+            assert!(!plan.is_shadowed(&digests[2].digest, b"d/b"));
+        }
+
+        /// Nothing under the replacement is created either. A directory there
+        /// would have to be made through whatever took the path, which is not
+        /// created here and so is not there yet to be followed.
+        #[test]
+        fn nothing_beneath_the_replacement_is_created_either() {
+            let dirs = dirs_of(&[
+                layer(vec![symlink("lib", "usr/lib"), dir("usr"), dir("usr/lib")]),
+                layer(vec![dir("lib/sub"), file("lib/sub/a")]),
+            ]);
+            assert!(
+                !dirs.iter().any(|entry| entry.starts_with("lib")),
+                "nothing may be created behind the link: {dirs:?}"
+            );
+            assert!(dirs.iter().any(|entry| entry == "usr/lib"), "{dirs:?}");
+        }
+    }
+
+    /// A directory entry does not take a path back from a symlink that already
+    /// resolves to a directory, which is what keeps `/lib -> usr/lib` standing
+    /// when a later layer also ships `lib/`.
     #[test]
-    fn whiteout_names_are_recognised() {
-        assert!(matches!(whiteout(b"dir/.wh..wh..opq"), Some(Whiteout::Opaque(d)) if d == b"dir"));
+    fn a_directory_entry_leaves_a_standing_symlink_alone() {
+        let dirs = dirs_of(&[
+            layer(vec![symlink("lib", "usr/lib"), dir("usr"), dir("usr/lib")]),
+            layer(vec![dir("lib")]),
+        ]);
+        assert!(!dirs.iter().any(|d| d == "lib"), "{dirs:?}");
+        assert!(dirs.iter().any(|d| d == "usr/lib"), "{dirs:?}");
+    }
+
+    #[test]
+    fn directories_are_listed_parents_first() {
+        let dirs = dirs_of(&[layer(vec![dir("a/b/c"), file("a/b/c/d"), dir("a")])]);
+        assert_eq!(dirs, ["a", "a/b", "a/b/c"], "including the ones nothing names");
+    }
+
+    #[test]
+    fn a_whiteout_takes_the_directory_it_names_out_of_the_tree() {
+        let dirs = dirs_of(&[
+            layer(vec![dir("gone"), file("gone/a"), dir("kept")]),
+            layer(vec![file(".wh.gone")]),
+        ]);
+        assert_eq!(dirs, ["kept"]);
+    }
+
+    #[test]
+    fn whiteout_names_are_recognised() {        assert!(matches!(whiteout(b"dir/.wh..wh..opq"), Some(Whiteout::Opaque(d)) if d == b"dir"));
         assert!(matches!(whiteout(b".wh..wh..opq"), Some(Whiteout::Opaque(d)) if d.is_empty()));
         assert!(matches!(whiteout(b"dir/.wh.name"), Some(Whiteout::Named(n)) if n == b"dir/name"));
         assert!(matches!(whiteout(b".wh.name"), Some(Whiteout::Named(n)) if n == b"name"));

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -771,3 +771,158 @@ fn a_digest_mismatch_wins_over_index_errors() {
     }
     let _ = fsutil::force_remove_dir_all(root.as_std_path());
 }
+
+/// Applies several layers to one rootfs with the plan in play, the way a real
+/// image runs, so that what the plan decides is checked against what the
+/// extractor then does rather than on its own.
+fn extract_planned(root: &Utf8Path, layers: &[Vec<u8>]) -> Result<Utf8PathBuf> {
+    let index_dir = root.join("indexes");
+    fs::create_dir_all(&index_dir).expect("index dir");
+
+    let mut descriptors = Vec::new();
+    for tar in layers {
+        let descriptor = install_blob(root, PLAIN_LAYER, tar);
+        let hex = parse_digest(&descriptor.digest).expect("digest").hex;
+        let table = crate::entries::Table::build(&tar[..]).expect("entry table");
+        let mut bytes = Vec::new();
+        table.write_to(&mut bytes).expect("serialise");
+        fs::write(index_dir.join(format!("{hex}.entries")), bytes).expect("install table");
+        descriptors.push(descriptor);
+    }
+    // `install_blob` rewrites index.json each time; the layers live in the
+    // manifest the caller passes to the extractor, not in the layout.
+    let layout = Layout::open(root)?;
+    let rootfs = root.join("rootfs");
+    let mut extractor = RootfsExtractor::new(&rootfs, Some(&index_dir))?;
+    extractor.plan(&descriptors)?;
+    for descriptor in &descriptors {
+        extractor.apply_layer(&layout, descriptor)?;
+    }
+    extractor.finish()?;
+    Ok(rootfs)
+}
+
+fn tar_of(build: impl FnOnce(&mut tar::Builder<Vec<u8>>)) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    build(&mut builder);
+    builder.into_inner().expect("tar")
+}
+
+fn append_dir(builder: &mut tar::Builder<Vec<u8>>, path: &str) {
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(EntryType::Directory);
+    header.set_mode(0o755);
+    header.set_size(0);
+    builder.append_data(&mut header, path, io::empty()).expect("dir");
+}
+
+fn append_file(builder: &mut tar::Builder<Vec<u8>>, path: &str, body: &[u8]) {
+    let mut header = tar::Header::new_gnu();
+    header.set_mode(0o644);
+    header.set_size(body.len() as u64);
+    builder.append_data(&mut header, path, body).expect("file");
+}
+
+fn append_symlink(builder: &mut tar::Builder<Vec<u8>>, path: &str, target: &str) {
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(EntryType::Symlink);
+    header.set_size(0);
+    builder.append_link(&mut header, path, target).expect("symlink");
+}
+
+/// A later layer turning a directory into a symlink is the case the plan has
+/// to get right: the files the earlier layer put in that directory are gone,
+/// and writing them anyway would send them through the link to somewhere they
+/// were never meant to be.
+#[test]
+fn a_directory_replaced_by_a_symlink_takes_its_contents_with_it() {
+    let root = scratch("planned-dir-to-symlink");
+    let rootfs = extract_planned(
+        &root,
+        &[
+            tar_of(|b| {
+                append_dir(b, "usr/");
+                append_dir(b, "usr/lib/");
+                append_file(b, "usr/lib/real", b"real");
+                append_dir(b, "lib/");
+                append_file(b, "lib/stale", b"stale");
+            }),
+            tar_of(|b| append_symlink(b, "lib", "usr/lib")),
+        ],
+    )
+    .expect("extract");
+
+    assert_eq!(
+        fs::read_link(rootfs.join("lib")).expect("symlink"),
+        Path::new("usr/lib"),
+        "the link the last layer asked for is what stands"
+    );
+    assert!(
+        !rootfs.join("usr/lib/stale").exists(),
+        "the replaced directory's contents must not reappear through the link"
+    );
+    assert_eq!(
+        fs::read_to_string(rootfs.join("usr/lib/real")).expect("real"),
+        "real"
+    );
+
+    let _ = fsutil::force_remove_dir_all(root.as_std_path());
+}
+
+/// The reverse: a symlink already standing where a later layer ships a
+/// directory keeps the link, so entries under it follow it.
+#[test]
+fn a_standing_symlink_survives_a_later_directory_entry() {
+    let root = scratch("planned-symlink-kept");
+    let rootfs = extract_planned(
+        &root,
+        &[
+            tar_of(|b| {
+                append_dir(b, "usr/");
+                append_dir(b, "usr/lib/");
+                append_symlink(b, "lib", "usr/lib");
+            }),
+            tar_of(|b| {
+                append_dir(b, "lib/");
+                append_file(b, "lib/through", b"through");
+            }),
+        ],
+    )
+    .expect("extract");
+
+    assert!(rootfs.join("lib").is_symlink(), "the link has to survive");
+    assert_eq!(
+        fs::read_to_string(rootfs.join("usr/lib/through")).expect("through"),
+        "through",
+        "an entry under the link lands where the link points"
+    );
+
+    let _ = fsutil::force_remove_dir_all(root.as_std_path());
+}
+
+/// Planning must not lose a whiteout: the marker is a regular file entry, and
+/// the tree it clears was built by layers the plan also resolved.
+#[test]
+fn a_planned_image_still_applies_its_whiteouts() {
+    let root = scratch("planned-whiteout");
+    let rootfs = extract_planned(
+        &root,
+        &[
+            tar_of(|b| {
+                append_dir(b, "d/");
+                append_file(b, "d/gone", b"gone");
+                append_file(b, "d/kept", b"kept");
+            }),
+            tar_of(|b| append_file(b, "d/.wh.gone", b"")),
+        ],
+    )
+    .expect("extract");
+
+    assert!(!rootfs.join("d/gone").exists());
+    assert_eq!(
+        fs::read_to_string(rootfs.join("d/kept")).expect("kept"),
+        "kept"
+    );
+
+    let _ = fsutil::force_remove_dir_all(root.as_std_path());
+}

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -83,7 +83,7 @@ fn run(args: RunArgs) -> Result<i32> {
 
     let rootfs = bundle.rootfs();
     let mut extractor = RootfsExtractor::new(&rootfs, args.index.as_deref())?;
-    extractor.plan(&manifest.layers);
+    extractor.plan(&manifest.layers)?;
     for layer in &manifest.layers {
         extractor.apply_layer(&layout, layer)?;
     }


### PR DESCRIPTION
Each layer discovers the directories it needs as it walks: stat the path, create it if nothing is there, remember its mode for the end. Every layer does this again for directories the ones before it already made, and none of it can be shared with anything running alongside.

The entry tables now let the whole image be replayed first, entry for entry, into the tree the layers build between them. That tree names the directories the image ends up with, so they are created up front and the layers stop dealing with directory entries at all.

Replaying means following the same rules the extractor does. A directory entry leaves a symlink that already stands where it wants to be, which is what keeps `/lib -> usr/lib` intact when a later layer also ships `lib/`. Anything else takes the path it names, and the tree underneath it, which is the case worth stating: a layer that replaces a directory with a symlink or a file removes what was in it, so those entries are neither placed nor planned for. Without that, an earlier layer's `lib/foo` would be written through a link a later layer introduced, rather than having gone with the directory it lived in.

Nothing is created behind such a path either. What stands there resolves somewhere else and is not created here, so there would be nothing to create it under; those entries keep resolving against the tree as the extractor builds it, as they always have.

This is groundwork rather than a saving. It takes per layer directory handling out of the walk, but that was not what the walk was waiting on:

```
chromium, extracting to disk, min of five interleaved rounds
wall 3.830 -> 3.737 s   cpu 16.487 -> 15.560 s
```

The extracted tree is identical, bar directory inode sizes, which shrink where the baseline had grown them creating and deleting entries that the resolved plan never creates.