### PR TITLE
Extract a resolved image span by span

### DIFF
--- a/e2e/smoke/cases.sh
+++ b/e2e/smoke/cases.sh
@@ -201,8 +201,8 @@ case_verbose_logging() {
     </dev/null 2>"${TEST_TMPDIR}/verbose.err")
   stderr=$(cat "${TEST_TMPDIR}/verbose.err")
   assert_equals "only-container-output" "$stdout" "verbose stdout"
-  assert_contains "$stderr" "Extracting layer" "verbose setup logging"
-  assert_not_contains "$stdout" "Extracting layer" "setup logging kept off stdout"
+  assert_contains "$stderr" "Extracting" "verbose setup logging"
+  assert_not_contains "$stdout" "Extracting" "setup logging kept off stdout"
 }
 
 case_signal_forwarding() {

--- a/source/src/entries.rs
+++ b/source/src/entries.rs
@@ -29,6 +29,10 @@ pub enum Kind {
     Directory,
     Symlink,
     HardLink,
+    /// A file whose body is stored as a sparse map rather than laid out flat,
+    /// so `offset` and `size` do not describe where its contents are. It takes
+    /// a path like any other file, but only `tar` knows how to place it.
+    Sparse,
     Unsupported,
 }
 
@@ -40,6 +44,7 @@ impl Kind {
             Kind::Symlink => 2,
             Kind::HardLink => 3,
             Kind::Unsupported => 4,
+            Kind::Sparse => 5,
         }
     }
 
@@ -50,8 +55,14 @@ impl Kind {
             2 => Kind::Symlink,
             3 => Kind::HardLink,
             4 => Kind::Unsupported,
+            5 => Kind::Sparse,
             _ => return None,
         })
+    }
+
+    /// True when the entry ends up as a regular file, however it is stored.
+    pub fn is_file(self) -> bool {
+        matches!(self, Kind::File | Kind::Sparse)
     }
 }
 
@@ -85,17 +96,19 @@ impl Table {
             let header = entry.header();
             let entry_type = header.entry_type();
             // Classified by what the extractor does with it, not by the type
-            // alone: a continuous file is a file, and a sparse one is placed
-            // like a file even though `tar` has to lay out its holes.
+            // alone: a continuous file is a plain file, while a sparse one
+            // ends up as a file but is not stored as one.
             let kind = if entry_type.is_dir() {
                 Kind::Directory
             } else if entry_type.is_symlink() {
                 Kind::Symlink
             } else if entry_type.is_hard_link() {
                 Kind::HardLink
+            } else if entry_type == tar::EntryType::GNUSparse {
+                Kind::Sparse
             } else if matches!(
                 entry_type,
-                tar::EntryType::Regular | tar::EntryType::Continuous | tar::EntryType::GNUSparse
+                tar::EntryType::Regular | tar::EntryType::Continuous
             ) {
                 Kind::File
             } else {

--- a/source/src/extract/file.rs
+++ b/source/src/extract/file.rs
@@ -69,11 +69,20 @@ pub(super) fn unpack_regular<R: Read>(
 
     // `mode` is what the file was created with, but the umask applies to
     // creation and not to this, so it is still needed to get the mode asked for.
-    file.set_permissions(fs::Permissions::from_mode(mode))?;
-    if let Ok(mtime) = entry.header().mtime() {
-        set_mtime(&file, mtime);
-    }
+    finish_file(&file, mode, entry.header().mtime().ok())?;
     Ok(replaced)
+}
+
+/// Gives a freshly written file the mode and timestamp its entry asked for.
+///
+/// The mode is applied again because the umask applies to creation but not to
+/// this, and it is the only way to end up with what the layer asked for.
+pub(super) fn finish_file(file: &fs::File, mode: u32, mtime: Option<u64>) -> io::Result<()> {
+    file.set_permissions(fs::Permissions::from_mode(mode))?;
+    if let Some(mtime) = mtime {
+        set_mtime(file, mtime);
+    }
+    Ok(())
 }
 
 fn open_exclusive(dst: &Path, mode: u32) -> io::Result<fs::File> {

--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -9,6 +9,7 @@ mod entry;
 mod file;
 mod pipeline;
 mod plan;
+mod spans;
 #[cfg(test)]
 mod tests;
 
@@ -86,6 +87,33 @@ impl RootfsExtractor {
         Ok(())
     }
 
+    /// Places every layer of the image.
+    ///
+    /// A resolved image whose entries are all placeable goes straight from the
+    /// plan: the spans of every layer become one queue of work, and each is
+    /// inflated and written by the same thread. Anything else is walked a
+    /// layer at a time, which is what has to happen when the plan cannot say
+    /// where an entry ends up without building the tree to find out.
+    pub fn apply(&mut self, layout: &Layout, descriptors: &[Descriptor]) -> Result<()> {
+        if let Some(work) = self.plan.work() {
+            // Every layer needs a checkpoint index, since a span is where a
+            // worker starts inflating. One checkpoint is enough: it means the
+            // layer is one span.
+            let indexes: Option<Vec<zinfo::Index>> = self
+                .index_dir
+                .as_deref()
+                .map(|dir| descriptors.iter().map(|d| index_at(dir, d)).collect())
+                .unwrap_or_default();
+            if let Some(indexes) = indexes {
+                return spans::extract(&self.rootfs, layout, descriptors, &self.plan, work, indexes);
+            }
+        }
+        for descriptor in descriptors {
+            self.apply_layer(layout, descriptor)?;
+        }
+        Ok(())
+    }
+
     /// Decompression is CPU bound and writing the rootfs is IO bound, so a
     /// second thread inflates the blob while this one writes the entries. The
     /// two overlap rather than run back to back, which on a large layer is
@@ -136,36 +164,12 @@ impl RootfsExtractor {
         }
     }
 
-    /// The checkpoint index for this layer, when there is one and parallel
-    /// decompression can put it to use. An index is an optimisation, so
-    /// anything wrong with it means falling back, not failing: the streaming
-    /// path decides what the blob actually contains.
+    /// The checkpoint index for this layer, when there is one and the
+    /// streaming pipeline can put it to use. One checkpoint is the whole blob,
+    /// which buys that path nothing.
     fn layer_index(&self, descriptor: &Descriptor) -> Option<zinfo::Index> {
-        let dir = self.index_dir.as_ref()?;
-        if compression_of(&descriptor.media_type) != Some(Compression::Gzip) {
-            return None;
-        }
-        if thread::available_parallelism().map_or(1, |n| n.get()) < 2 {
-            return None;
-        }
-        let hex = parse_digest(&descriptor.digest).ok()?.hex;
-        let path = dir.join(format!("{hex}.zinfo"));
-        let file = match fs::File::open(&path) {
-            Ok(file) => file,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return None,
-            Err(err) => {
-                warning!("ignoring layer index {path}: {err}");
-                return None;
-            }
-        };
-        match zinfo::Index::read_from(io::BufReader::new(file)) {
-            Ok(index) if index.checkpoints.len() > 1 => Some(index),
-            Ok(_) => None,
-            Err(err) => {
-                warning!("ignoring layer index {path}: {err}");
-                None
-            }
-        }
+        index_at(self.index_dir.as_deref()?, descriptor)
+            .filter(|index| index.checkpoints.len() > 1)
     }
 
     /// Applies the recorded directory permissions, deepest first.
@@ -182,5 +186,36 @@ impl RootfsExtractor {
             }
         }
         Ok(())
+    }
+}
+
+/// Reads the checkpoint index recorded for a layer, if there is a usable one.
+///
+/// An index is an optimisation, so anything wrong with it means falling back
+/// rather than failing: whichever path ends up reading the layer decides what
+/// it actually contains.
+fn index_at(dir: &Utf8Path, descriptor: &Descriptor) -> Option<zinfo::Index> {
+    if compression_of(&descriptor.media_type) != Some(Compression::Gzip) {
+        return None;
+    }
+    if thread::available_parallelism().map_or(1, |n| n.get()) < 2 {
+        return None;
+    }
+    let hex = parse_digest(&descriptor.digest).ok()?.hex;
+    let path = dir.join(format!("{hex}.zinfo"));
+    let file = match fs::File::open(&path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            warning!("ignoring layer index {path}: {err}");
+            return None;
+        }
+    };
+    match zinfo::Index::read_from(io::BufReader::new(file)) {
+        Ok(index) => Some(index),
+        Err(err) => {
+            warning!("ignoring layer index {path}: {err}");
+            None
+        }
     }
 }

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -40,6 +40,24 @@ pub struct Plan {
     /// False when the image could not be resolved, and every layer therefore
     /// has to be placed in full.
     resolved: bool,
+    /// What survives, for a caller that means to place it directly rather than
+    /// by walking the layers. `None` when something in the image rules that
+    /// out; see [`Plan::placeable`].
+    work: Option<Work>,
+    tables: Vec<Table>,
+}
+
+/// The surviving entries, grouped the way they have to be placed.
+#[derive(Default)]
+pub struct Work {
+    /// Regular files, by layer, ordered by where their bodies sit in the
+    /// layer's uncompressed stream.
+    pub files: Vec<Vec<u32>>,
+    /// Symlinks, shallowest path first, so one standing under another has
+    /// somewhere to be.
+    pub symlinks: Vec<(u32, u32)>,
+    /// Hard links, which need the files they name to be on disk already.
+    pub hard_links: Vec<(u32, u32)>,
 }
 
 impl Plan {
@@ -75,10 +93,10 @@ impl Plan {
                 }
             }
         }
-        Plan::resolve(layers, &tables)
+        Plan::resolve(layers, tables)
     }
 
-    fn resolve(layers: &[Descriptor], tables: &[Table]) -> Plan {
+    fn resolve(layers: &[Descriptor], tables: Vec<Table>) -> Plan {
         // A hard link is made against what is already on disk, so whatever it
         // names has to be placed even where a later layer replaces it. There
         // are single figures of these in a real image.
@@ -89,7 +107,7 @@ impl Plan {
             .map(|entry| entry.link.as_slice())
             .collect();
 
-        let tree = replay(tables);
+        let tree = replay(&tables);
 
         let mut shadowed: HashMap<String, HashSet<Vec<u8>>> = HashMap::new();
         let mut total = 0;
@@ -99,7 +117,7 @@ impl Plan {
             for (e, entry) in table.entries.iter().enumerate() {
                 // Only bodies are worth skipping, and a whiteout marker has to
                 // reach the extractor or nothing gets removed.
-                if entry.kind != Kind::File || whiteout(&entry.path).is_some() {
+                if !entry.kind.is_file() || whiteout(&entry.path).is_some() {
                     continue;
                 }
                 if linked.contains(entry.path.as_slice()) {
@@ -124,10 +142,14 @@ impl Plan {
                 bytes >> 20
             );
         }
+        let directories = directories(&tree);
+        let work = placeable(&tree, &tables);
         Plan {
             shadowed,
-            directories: directories(&tree),
+            directories,
             resolved: true,
+            work,
+            tables,
         }
     }
 
@@ -142,6 +164,16 @@ impl Plan {
         &self.directories
     }
 
+    /// What survives, when the image is one that can be placed straight from
+    /// the plan rather than by walking its layers.
+    pub fn work(&self) -> Option<&Work> {
+        self.work.as_ref()
+    }
+
+    pub fn table(&self, layer: usize) -> &Table {
+        &self.tables[layer]
+    }
+
     /// True when this layer's copy of `path` is replaced or removed by a later
     /// one, and so never has to be written.
     pub fn is_shadowed(&self, digest: &str, path: &[u8]) -> bool {
@@ -149,6 +181,40 @@ impl Plan {
             .get(digest)
             .is_some_and(|doomed| doomed.contains(path))
     }
+}
+
+/// Groups the surviving entries for a caller that will place them directly.
+///
+/// Returns `None` where the image holds something that only a walk of the
+/// layers can deal with:
+///
+/// - a sparse file, whose body is not a flat run of the stream, so nothing can
+///   be written from an offset and a length;
+/// - an entry that resolves through a symlink, where the path the layer spells
+///   is not the path it lands on, and working that out means resolving against
+///   the tree as it is built.
+fn placeable(tree: &BTreeMap<&[u8], Node>, tables: &[Table]) -> Option<Work> {
+    let mut work = Work {
+        files: vec![Vec::new(); tables.len()],
+        ..Work::default()
+    };
+    for (path, node) in tree {
+        let (layer, entry) = node.owner;
+        match node.kind {
+            Kind::Directory | Kind::Unsupported => continue,
+            Kind::Sparse => return None,
+            _ if behind_a_link(tree, path) => return None,
+            Kind::File => work.files[layer].push(entry as u32),
+            // A `BTreeMap` orders by path, so a link under another link is
+            // already after it.
+            Kind::Symlink => work.symlinks.push((layer as u32, entry as u32)),
+            Kind::HardLink => work.hard_links.push((layer as u32, entry as u32)),
+        }
+    }
+    for (layer, entries) in work.files.iter_mut().enumerate() {
+        entries.sort_unstable_by_key(|&e| tables[layer].entries[e as usize].offset);
+    }
+    Some(work)
 }
 
 /// What the layers leave at a path once all of them have been applied.
@@ -375,7 +441,7 @@ mod tests {
     }
 
     /// The paths the plan would create as directories, for readability.
-    fn dirs_of(layers: &[Table]) -> Vec<String> {
+    fn dirs_of(layers: Vec<Table>) -> Vec<String> {
         let (plan, _) = plan_of(layers);
         plan.directories()
             .iter()
@@ -389,14 +455,14 @@ mod tests {
         }
     }
 
-    fn plan_of(layers: &[Table]) -> (Plan, Vec<Descriptor>) {
+    fn plan_of(layers: Vec<Table>) -> (Plan, Vec<Descriptor>) {
         let descriptors: Vec<Descriptor> = (0..layers.len() as u8).map(descriptor).collect();
         (Plan::resolve(&descriptors, layers), descriptors)
     }
 
     #[test]
     fn a_later_layer_shadows_an_earlier_copy() {
-        let (plan, d) = plan_of(&[table(&["a", "keep"]), table(&["a"])]);
+        let (plan, d) = plan_of(vec![table(&["a", "keep"]), table(&["a"])]);
         assert!(plan.is_shadowed(&d[0].digest, b"a"));
         assert!(!plan.is_shadowed(&d[0].digest, b"keep"));
         assert!(!plan.is_shadowed(&d[1].digest, b"a"), "the winner stays");
@@ -404,7 +470,7 @@ mod tests {
 
     #[test]
     fn a_whiteout_shadows_what_it_hides() {
-        let (plan, d) = plan_of(&[table(&["dir/a", "dir/b", "other"]), table(&["dir/.wh.a"])]);
+        let (plan, d) = plan_of(vec![table(&["dir/a", "dir/b", "other"]), table(&["dir/.wh.a"])]);
         assert!(plan.is_shadowed(&d[0].digest, b"dir/a"));
         assert!(!plan.is_shadowed(&d[0].digest, b"dir/b"));
         assert!(!plan.is_shadowed(&d[0].digest, b"other"));
@@ -414,14 +480,14 @@ mod tests {
     /// it or nothing is removed from the tree the lower layers built.
     #[test]
     fn a_whiteout_marker_is_never_shadowed() {
-        let (plan, d) = plan_of(&[table(&["dir/.wh.a"]), table(&["dir/.wh.a"])]);
+        let (plan, d) = plan_of(vec![table(&["dir/.wh.a"]), table(&["dir/.wh.a"])]);
         assert!(!plan.is_shadowed(&d[0].digest, b"dir/.wh.a"));
         assert!(!plan.is_shadowed(&d[1].digest, b"dir/.wh.a"));
     }
 
     #[test]
     fn an_opaque_whiteout_shadows_the_directory_it_names() {
-        let (plan, d) = plan_of(&[
+        let (plan, d) = plan_of(vec![
             table(&["dir/a", "dir/sub/b", "dirty", "elsewhere"]),
             table(&["dir/.wh..wh..opq"]),
         ]);
@@ -436,7 +502,7 @@ mod tests {
 
     #[test]
     fn a_whiteout_of_a_directory_shadows_what_is_under_it() {
-        let (plan, d) = plan_of(&[table(&["dir/a", "dir", "dirty"]), table(&["\
+        let (plan, d) = plan_of(vec![table(&["dir/a", "dir", "dirty"]), table(&["\
 .wh.dir"])]);
         assert!(plan.is_shadowed(&d[0].digest, b"dir/a"));
         assert!(plan.is_shadowed(&d[0].digest, b"dir"));
@@ -446,7 +512,7 @@ mod tests {
     /// A later layer restoring a path the whiteout removed keeps it.
     #[test]
     fn a_path_written_after_a_whiteout_survives() {
-        let (plan, d) = plan_of(&[table(&["a"]), table(&[".wh.a"]), table(&["a"])]);
+        let (plan, d) = plan_of(vec![table(&["a"]), table(&[".wh.a"]), table(&["a"])]);
         assert!(plan.is_shadowed(&d[0].digest, b"a"));
         assert!(!plan.is_shadowed(&d[2].digest, b"a"));
     }
@@ -459,7 +525,7 @@ mod tests {
         linking.entries[0].kind = Kind::HardLink;
         linking.entries[0].link = b"target".to_vec();
 
-        let (plan, d) = plan_of(&[table(&["target"]), linking, table(&["target"])]);
+        let (plan, d) = plan_of(vec![table(&["target"]), linking, table(&["target"])]);
         assert!(
             !plan.is_shadowed(&d[0].digest, b"target"),
             "the copy the link was made against has to be placed"
@@ -482,7 +548,7 @@ mod tests {
 
         #[test]
         fn a_symlink_takes_the_tree_under_it() {
-            let (plan, d) = plan_of(&[
+            let (plan, d) = plan_of(vec![
                 layer(vec![dir("lib"), file("lib/a"), file("lib/sub/b"), file("libre")]),
                 layer(vec![symlink("lib", "usr/lib")]),
             ]);
@@ -496,7 +562,7 @@ mod tests {
 
         #[test]
         fn a_file_takes_the_tree_under_it() {
-            let (plan, d) = plan_of(&[
+            let (plan, d) = plan_of(vec![
                 layer(vec![dir("d"), file("d/a")]),
                 layer(vec![file("d")]),
             ]);
@@ -507,7 +573,7 @@ mod tests {
         fn a_hard_link_takes_the_tree_under_it() {
             let mut link = of_kind("d", Kind::HardLink);
             link.link = b"elsewhere".to_vec();
-            let (plan, d) = plan_of(&[
+            let (plan, d) = plan_of(vec![
                 layer(vec![dir("d"), file("d/a"), file("elsewhere")]),
                 layer(vec![link]),
             ]);
@@ -517,7 +583,7 @@ mod tests {
         /// The path is gone, so nothing may be created there as a directory.
         #[test]
         fn the_replaced_path_is_not_created_as_a_directory() {
-            let dirs = dirs_of(&[
+            let dirs = dirs_of(vec![
                 layer(vec![dir("lib"), file("lib/a")]),
                 layer(vec![symlink("lib", "usr/lib")]),
             ]);
@@ -530,14 +596,14 @@ mod tests {
         /// Restoring the directory afterwards puts everything back in play.
         #[test]
         fn a_directory_put_back_afterwards_is_a_directory_again() {
-            let dirs = dirs_of(&[
+            let dirs = dirs_of(vec![
                 layer(vec![dir("d"), file("d/a")]),
                 layer(vec![file("d")]),
                 layer(vec![dir("d"), file("d/b")]),
             ]);
             assert!(dirs.iter().any(|entry| entry == "d"), "{dirs:?}");
 
-            let (plan, digests) = plan_of(&[
+            let (plan, digests) = plan_of(vec![
                 layer(vec![dir("d"), file("d/a")]),
                 layer(vec![file("d")]),
                 layer(vec![dir("d"), file("d/b")]),
@@ -551,7 +617,7 @@ mod tests {
         /// created here and so is not there yet to be followed.
         #[test]
         fn nothing_beneath_the_replacement_is_created_either() {
-            let dirs = dirs_of(&[
+            let dirs = dirs_of(vec![
                 layer(vec![symlink("lib", "usr/lib"), dir("usr"), dir("usr/lib")]),
                 layer(vec![dir("lib/sub"), file("lib/sub/a")]),
             ]);
@@ -568,7 +634,7 @@ mod tests {
     /// when a later layer also ships `lib/`.
     #[test]
     fn a_directory_entry_leaves_a_standing_symlink_alone() {
-        let dirs = dirs_of(&[
+        let dirs = dirs_of(vec![
             layer(vec![symlink("lib", "usr/lib"), dir("usr"), dir("usr/lib")]),
             layer(vec![dir("lib")]),
         ]);
@@ -578,13 +644,13 @@ mod tests {
 
     #[test]
     fn directories_are_listed_parents_first() {
-        let dirs = dirs_of(&[layer(vec![dir("a/b/c"), file("a/b/c/d"), dir("a")])]);
+        let dirs = dirs_of(vec![layer(vec![dir("a/b/c"), file("a/b/c/d"), dir("a")])]);
         assert_eq!(dirs, ["a", "a/b", "a/b/c"], "including the ones nothing names");
     }
 
     #[test]
     fn a_whiteout_takes_the_directory_it_names_out_of_the_tree() {
-        let dirs = dirs_of(&[
+        let dirs = dirs_of(vec![
             layer(vec![dir("gone"), file("gone/a"), dir("kept")]),
             layer(vec![file(".wh.gone")]),
         ]);

--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -1,0 +1,395 @@
+//! Extracting a resolved image span by span.
+//!
+//! Once the whole image has been resolved there is no reason to walk it a
+//! layer at a time. Every surviving file is known, along with the layer it
+//! comes from and where its body sits in that layer's uncompressed stream, and
+//! the checkpoint index says where inflating can start. So the image is cut
+//! into spans and handed to a pool.
+//!
+//! A worker inflates its own span and writes the files that begin inside it,
+//! straight out of the buffer it inflated into. Nothing is handed between
+//! threads, so nothing is copied, and bytes are written while they are still
+//! in the cache of the core that produced them. That is the difference between
+//! this and an earlier attempt that had one thread parse and others write:
+//! buffering a body to hand it over roughly doubled the memory traffic per
+//! byte, and no amount of parallelism paid that back.
+//!
+//! Work is claimed from one queue covering every layer, so a worker held up by
+//! a large file does not stall the rest and later layers start as soon as
+//! there is capacity for them.
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread;
+
+use camino::Utf8Path;
+use sha2::{Digest, Sha256};
+
+use crate::entries::{Entry, Table};
+use crate::error::{Error, IoContext, Result};
+use crate::image::{Descriptor, Layout, hex_encode, parse_digest};
+use crate::log::log;
+use crate::sys::Mapping;
+use crate::zinfo;
+
+use super::file::{finish_file, set_symlink_mtime};
+use super::plan::{Plan, Work};
+
+/// Everything one layer contributes, held open for the length of the run.
+struct Layer {
+    descriptor: Descriptor,
+    blob: Mapping,
+    index: zinfo::Index,
+}
+
+/// A claim on the queue.
+enum Unit {
+    /// Inflate from a checkpoint and write the files beginning inside it.
+    Span {
+        layer: usize,
+        checkpoint: usize,
+        /// Indices into the layer's entry table, ordered by body offset.
+        entries: std::ops::Range<usize>,
+    },
+    /// Check a blob against the digest its descriptor names. The bytes are
+    /// mapped once and read by both this and the spans, so it costs a pass
+    /// over memory rather than a second read of the file.
+    Digest { layer: usize },
+}
+
+impl Unit {
+    /// Roughly how long the unit will take, so the longest go first and the
+    /// tail of the run is short.
+    fn weight(&self, layers: &[Layer], work: &Work, plan: &Plan) -> u64 {
+        match self {
+            Unit::Digest { layer } => layers[*layer].blob.len() as u64,
+            Unit::Span {
+                layer,
+                checkpoint,
+                entries,
+            } => {
+                let index = &layers[*layer].index;
+                let table = plan.table(*layer);
+                let last = work.files[*layer][entries.end - 1] as usize;
+                let entry = &table.entries[last];
+                entry.offset + entry.size - index.checkpoints[*checkpoint].out_offset
+            }
+        }
+    }
+}
+
+/// Places every surviving entry of a resolved image.
+///
+/// The directories are already there, so a worker never has to work out where
+/// an entry can go: it opens the path exclusively, which neither follows a
+/// symlink nor overwrites anything. The plan says each path is placed once, so
+/// a path that is already occupied means the plan and the tree disagree, and
+/// that is an error rather than something to write through.
+pub fn extract(
+    rootfs: &Utf8Path,
+    layout: &Layout,
+    descriptors: &[Descriptor],
+    plan: &Plan,
+    work: &Work,
+    indexes: Vec<zinfo::Index>,
+) -> Result<()> {
+    let layers = open_layers(layout, descriptors, indexes)?;
+    let root = rootfs.as_std_path();
+
+    // Symlinks first: nothing resolves through one here, or the plan would
+    // have refused the image, but a link under another link needs it standing.
+    for &(layer, entry) in &work.symlinks {
+        let entry = &plan.table(layer as usize).entries[entry as usize];
+        place_symlink(root, entry)?;
+    }
+
+    let units = plan_units(&layers, work, plan);
+    log!(
+        "Extracting {} layers from {} checkpoints as {} units on {} workers",
+        layers.len(),
+        layers
+            .iter()
+            .map(|layer| layer.index.checkpoints.len())
+            .sum::<usize>(),
+        units.len(),
+        workers(units.len())
+    );
+    run(&units, &layers, work, plan, root)?;
+
+    // Hard links last: the files they name are on disk by now.
+    for &(layer, entry) in &work.hard_links {
+        let entry = &plan.table(layer as usize).entries[entry as usize];
+        place_hard_link(root, entry)?;
+    }
+    Ok(())
+}
+
+fn open_layers(
+    layout: &Layout,
+    descriptors: &[Descriptor],
+    indexes: Vec<zinfo::Index>,
+) -> Result<Vec<Layer>> {
+    descriptors
+        .iter()
+        .zip(indexes)
+        .map(|(descriptor, index)| {
+            let file = layout.open_blob(descriptor)?;
+            let len = file.metadata().map_or(0, |m| m.len()) as usize;
+            let blob = Mapping::of(&file, len).ok_or_else(|| {
+                Error::io(
+                    format!("mapping layer {}", descriptor.digest),
+                    std::io::Error::other("the blob could not be mapped"),
+                )
+            })?;
+            Ok(Layer {
+                descriptor: descriptor.clone(),
+                blob,
+                index,
+            })
+        })
+        .collect()
+}
+
+/// Cuts the image into units: the files beginning within one checkpoint's
+/// span, plus one digest check per layer.
+///
+/// A body can run past the end of the span it starts in, and whoever writes it
+/// inflates far enough to reach the end. The next unit picks up from the last
+/// checkpoint that one had to read, so a run of straddling files is not read
+/// twice over: cutting at every checkpoint regardless cost a third again as
+/// much processor time.
+///
+/// The window a unit takes from is fixed by the checkpoint it starts at, not
+/// by what it has absorbed. Letting that grow chains a whole layer into one
+/// unit, which is correct and useless: it leaves the other cores nothing.
+fn plan_units(layers: &[Layer], work: &Work, plan: &Plan) -> Vec<Unit> {
+    let mut units = Vec::new();
+    for (l, layer) in layers.iter().enumerate() {
+        units.push(Unit::Digest { layer: l });
+
+        let files = &work.files[l];
+        let table = plan.table(l);
+        let checkpoints = &layer.index.checkpoints;
+        let span_end = |c: usize| {
+            checkpoints
+                .get(c + 1)
+                .map_or(layer.index.uncompressed_len, |next| next.out_offset)
+        };
+        let body = |i: usize| {
+            let entry = &table.entries[files[i] as usize];
+            (entry.offset, entry.offset + entry.size)
+        };
+
+        let mut at = 0;
+        let mut checkpoint = 0;
+        while at < files.len() {
+            while checkpoint + 1 < checkpoints.len()
+                && checkpoints[checkpoint + 1].out_offset <= body(at).0
+            {
+                checkpoint += 1;
+            }
+
+            let first = at;
+            let limit = span_end(checkpoint);
+            let mut end = body(at).1;
+            while at < files.len() && body(at).0 < limit {
+                end = body(at).1;
+                at += 1;
+            }
+            units.push(Unit::Span {
+                layer: l,
+                checkpoint,
+                entries: first..at,
+            });
+
+            // Resume from the last checkpoint this unit had to inflate. Files
+            // still beginning there put the next unit back on it, which is the
+            // only place the two overlap.
+            while checkpoint + 1 < checkpoints.len() && span_end(checkpoint) < end {
+                checkpoint += 1;
+            }
+        }
+    }
+    units.sort_by_key(|unit| std::cmp::Reverse(unit.weight(layers, work, plan)));
+    units
+}
+
+/// Past a point another worker buys nothing: inflating and writing are both
+/// memory bound, and the cores end up queueing for the same bandwidth. On a
+/// sixteen core machine eight was the peak, and sixteen was worse than four
+/// on both wall clock and processor time.
+const MAX_WORKERS: usize = 8;
+
+fn workers(units: usize) -> usize {
+    thread::available_parallelism()
+        .map_or(1, |n| n.get())
+        .min(units.max(1))
+        .min(MAX_WORKERS)
+}
+
+fn run(
+    units: &[Unit],
+    layers: &[Layer],
+    work: &Work,
+    plan: &Plan,
+    root: &Path,
+) -> Result<()> {
+    let next = AtomicUsize::new(0);
+    let stop = AtomicBool::new(false);
+    // Reported by position in the queue rather than by whoever failed first,
+    // so the same broken image fails the same way every time.
+    let failure: Mutex<Option<(usize, Error)>> = Mutex::new(None);
+
+    thread::scope(|scope| {
+        for _ in 0..workers(units.len()) {
+            let (next, stop, failure) = (&next, &stop, &failure);
+            scope.spawn(move || {
+                let mut buffer = Vec::new();
+                let mut path = PathBuf::new();
+                while !stop.load(Ordering::Relaxed) {
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(unit) = units.get(i) else { break };
+                    let result = match unit {
+                        Unit::Digest { layer } => verify(&layers[*layer]),
+                        Unit::Span {
+                            layer,
+                            checkpoint,
+                            entries,
+                        } => run_span(
+                            &layers[*layer],
+                            plan.table(*layer),
+                            &work.files[*layer][entries.clone()],
+                            *checkpoint,
+                            root,
+                            &mut buffer,
+                            &mut path,
+                        ),
+                    };
+                    if let Err(err) = result {
+                        let mut slot = failure.lock().expect("a worker failure");
+                        if slot.as_ref().is_none_or(|(first, _)| i < *first) {
+                            *slot = Some((i, err));
+                        }
+                        stop.store(true, Ordering::Relaxed);
+                        break;
+                    }
+                }
+            });
+        }
+    });
+
+    match failure.into_inner().expect("a worker failure") {
+        Some((_, err)) => Err(err),
+        None => Ok(()),
+    }
+}
+
+/// Inflates from `checkpoint` far enough to cover `entries`, then writes each
+/// of them out of the buffer it inflated into.
+fn run_span(
+    layer: &Layer,
+    table: &Table,
+    entries: &[u32],
+    checkpoint: usize,
+    root: &Path,
+    buffer: &mut Vec<u8>,
+    path: &mut PathBuf,
+) -> Result<()> {
+    let base = layer.index.checkpoints[checkpoint].out_offset;
+    let last = &table.entries[*entries.last().expect("a unit has entries") as usize];
+    let needed = last.offset + last.size - base;
+
+    // A body can run past the end of its own span, so the run continues into
+    // the ones after it. They are claimed by whoever needs them.
+    buffer.clear();
+    let mut at = checkpoint;
+    while (buffer.len() as u64) < needed {
+        if at >= layer.index.checkpoints.len() {
+            return Err(Error::io(
+                format!("extracting layer {}", layer.descriptor.digest),
+                std::io::Error::other("an entry runs past the end of the layer"),
+            ));
+        }
+        layer.index.extract_span_into(&layer.blob, at, buffer)?;
+        at += 1;
+    }
+
+    for &entry in entries {
+        let entry = &table.entries[entry as usize];
+        let from = (entry.offset - base) as usize;
+        let to = from + entry.size as usize;
+        let body = buffer.get(from..to).ok_or_else(|| {
+            Error::io(
+                format!("extracting layer {}", layer.descriptor.digest),
+                std::io::Error::other("an entry lies outside the span it was planned into"),
+            )
+        })?;
+        write_file(root, path, entry, body)?;
+    }
+    Ok(())
+}
+
+fn write_file(root: &Path, path: &mut PathBuf, entry: &Entry, body: &[u8]) -> Result<()> {
+    resolve(root, path, entry);
+    let context = || format!("extracting {:?}", String::from_utf8_lossy(&entry.path));
+    // Exclusive, so this neither follows a symlink standing here nor writes
+    // over something the plan did not account for.
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(entry.mode)
+        .open(&path)
+        .io_context(context)?;
+    file.write_all(body).io_context(context)?;
+    finish_file(&file, entry.mode, Some(entry.mtime)).io_context(context)
+}
+
+fn place_symlink(root: &Path, entry: &Entry) -> Result<()> {
+    let mut path = PathBuf::new();
+    resolve(root, &mut path, entry);
+    let target = Path::new(std::ffi::OsStr::from_bytes(&entry.link));
+    std::os::unix::fs::symlink(target, &path)
+        .io_context(|| format!("linking {:?}", String::from_utf8_lossy(&entry.path)))?;
+    set_symlink_mtime(&path, entry.mtime);
+    Ok(())
+}
+
+fn place_hard_link(root: &Path, entry: &Entry) -> Result<()> {
+    let mut path = PathBuf::new();
+    resolve(root, &mut path, entry);
+    let mut source = PathBuf::new();
+    source.push(root);
+    source.push(std::ffi::OsStr::from_bytes(&entry.link));
+    fs::hard_link(&source, &path)
+        .io_context(|| format!("linking {:?}", String::from_utf8_lossy(&entry.path)))
+}
+
+fn resolve(root: &Path, path: &mut PathBuf, entry: &Entry) {
+    path.clear();
+    path.push(root);
+    path.push(std::ffi::OsStr::from_bytes(&entry.path));
+}
+
+fn verify(layer: &Layer) -> Result<()> {
+    let descriptor = &layer.descriptor;
+    if descriptor.size != 0 && descriptor.size != layer.blob.len() as u64 {
+        return Err(Error::SizeMismatch {
+            digest: descriptor.digest.clone(),
+            expected: descriptor.size,
+            actual: layer.blob.len() as u64,
+        });
+    }
+    let actual = hex_encode(&Sha256::digest(&*layer.blob));
+    if actual != parse_digest(&descriptor.digest)?.hex {
+        return Err(Error::DigestMismatch {
+            digest: descriptor.digest.clone(),
+            actual,
+        });
+    }
+    Ok(())
+}

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -84,9 +84,7 @@ fn run(args: RunArgs) -> Result<i32> {
     let rootfs = bundle.rootfs();
     let mut extractor = RootfsExtractor::new(&rootfs, args.index.as_deref())?;
     extractor.plan(&manifest.layers)?;
-    for layer in &manifest.layers {
-        extractor.apply_layer(&layout, layer)?;
-    }
+    extractor.apply(&layout, &manifest.layers)?;
 
     let hostname = args
         .hostname

--- a/source/src/zinfo.rs
+++ b/source/src/zinfo.rs
@@ -125,6 +125,14 @@ impl Index {
     /// Inflates the span between checkpoint `i` and its successor (or the end
     /// of the stream) and verifies it against the recorded CRC.
     pub fn extract_span(&self, blob: &[u8], i: usize) -> Result<Vec<u8>> {
+        let mut out = Vec::new();
+        self.extract_span_into(blob, i, &mut out)?;
+        Ok(out)
+    }
+
+    /// The same, appending to a buffer the caller keeps, so a reader working
+    /// through a run of spans neither reallocates nor copies between them.
+    pub fn extract_span_into(&self, blob: &[u8], i: usize, out: &mut Vec<u8>) -> Result<()> {
         let context = "resuming from checkpoint";
         let point = &self.checkpoints[i];
         let end = self
@@ -164,12 +172,14 @@ impl Index {
                 .map_err(|e| Error::io(context, e))?;
         }
 
-        let mut out = vec![0u8; len];
+        let base = out.len();
+        out.resize(base + len, 0);
+        let span = &mut out[base..];
         let mut in_pos = point.in_offset as usize;
         let mut filled = 0usize;
         while filled < len {
             let (consumed, produced, ret) = inflater
-                .inflate(&blob[in_pos..], &mut out[filled..], Flush::None)
+                .inflate(&blob[in_pos..], &mut span[filled..], Flush::None)
                 .map_err(|e| Error::io(context, e))?;
             in_pos += consumed;
             filled += produced;
@@ -196,14 +206,14 @@ impl Index {
         }
 
         let mut crc = flate2::Crc::new();
-        crc.update(&out);
+        crc.update(span);
         if crc.sum() != point.crc {
             return Err(Error::io(
                 context,
                 io::Error::other(format!("checkpoint {i} does not match its span checksum")),
             ));
         }
-        Ok(out)
+        Ok(())
     }
 
     pub fn write_to(&self, mut writer: impl Write) -> io::Result<()> {


### PR DESCRIPTION
Once the image has been resolved there is no reason to walk it a layer at a time. Every surviving file is known, along with the layer it comes from and where its body sits in that layer's uncompressed stream, and the checkpoint index says where inflating can start. So the image is cut into spans and handed to a pool.

A worker inflates its own span and writes the files that begin inside it, straight out of the buffer it inflated into. Nothing is handed between threads, so nothing is copied, and bytes are written while they are still in the cache of the core that produced them. That is what distinguishes this from an earlier attempt that had one thread parse and others write: buffering a body to hand it over roughly doubled the memory traffic per byte, and no amount of parallelism paid that back.

Work is claimed from one queue covering every layer, so a worker held up by a large file does not stall the rest and later layers start as soon as there is capacity. Digest checks are units too, so verifying a blob fills a core that would otherwise be waiting.

Directories already exist, so a worker never works out where an entry can go. It opens the path exclusively, which neither follows a symlink nor overwrites: the plan says each path is placed once, so an occupied path means the plan and the tree disagree, and that is an error rather than something to write through.

Three things decide against this route, and each falls back to walking the layers: a layer without a checkpoint index; a sparse file, whose body is not a flat run of the stream; and an entry that resolves through a symlink, where the path a layer spells is not the path it lands on. Sparse entries now have their own kind so they cannot be mistaken for ordinary files.

Two things had to be measured rather than assumed. Cutting a unit at every checkpoint left each one re-inflating what the last had read, for a third again as much processor time; a unit now resumes from the last checkpoint its predecessor needed. And more workers stop helping once inflating and writing saturate memory bandwidth: on sixteen cores, eight was the peak and sixteen was worse than four on both measures.

```
workers   1      2      4      8      16
wall      7.50   4.54   2.94   1.52   2.38
cpu       8.56   7.96   9.10   12.11  19.19
```

Measured on ghcr.io/browserless/chromium (22 layers, 1015 MiB compressed, 73,164 entries), release musl, extracted tree identical:

```
tmpfs, min of ten interleaved rounds
  wall 2.842 -> 1.846 s   cpu 12.711 -> 11.175 s
disk, min of five
  wall 6.124 -> 2.771 s   cpu 19.187 -> 19.819 s
```