### PR TITLE
perf: stop zeroing a span buffer once per unit

### DIFF
--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -306,16 +306,20 @@ fn run_span(
 
     // A body can run past the end of its own span, so the run continues into
     // the ones after it. They are claimed by whoever needs them.
-    buffer.clear();
+    //
+    // `filled` is what this unit inflated, which is not the buffer's length:
+    // the buffer keeps whatever the last unit grew it to, so that growing it
+    // is the only thing that has to zero anything.
+    let mut filled = 0usize;
     let mut at = checkpoint;
-    while (buffer.len() as u64) < needed {
+    while (filled as u64) < needed {
         if at >= layer.index.checkpoints.len() {
             return Err(Error::io(
                 format!("extracting layer {}", layer.descriptor.digest),
                 std::io::Error::other("an entry runs past the end of the layer"),
             ));
         }
-        layer.index.extract_span_into(&layer.blob, at, buffer)?;
+        filled += layer.index.extract_span_into(&layer.blob, at, buffer, filled)?;
         at += 1;
     }
 
@@ -323,7 +327,11 @@ fn run_span(
         let entry = &table.entries[entry as usize];
         let from = (entry.offset - base) as usize;
         let to = from + entry.size as usize;
-        let body = buffer.get(from..to).ok_or_else(|| {
+        // Bounded by what this unit inflated rather than by the buffer, which
+        // keeps the length the widest unit before it needed. `needed` above is
+        // taken from the last entry, so this holds already; slicing says so
+        // rather than leaving the buffer free to answer with stale bytes.
+        let body = buffer[..filled].get(from..to).ok_or_else(|| {
             Error::io(
                 format!("extracting layer {}", layer.descriptor.digest),
                 std::io::Error::other("an entry lies outside the span it was planned into"),

--- a/source/src/zinfo.rs
+++ b/source/src/zinfo.rs
@@ -126,13 +126,23 @@ impl Index {
     /// of the stream) and verifies it against the recorded CRC.
     pub fn extract_span(&self, blob: &[u8], i: usize) -> Result<Vec<u8>> {
         let mut out = Vec::new();
-        self.extract_span_into(blob, i, &mut out)?;
+        self.extract_span_into(blob, i, &mut out, 0)?;
         Ok(out)
     }
 
-    /// The same, appending to a buffer the caller keeps, so a reader working
-    /// through a run of spans neither reallocates nor copies between them.
-    pub fn extract_span_into(&self, blob: &[u8], i: usize, out: &mut Vec<u8>) -> Result<()> {
+    /// The same, into `out` at `at`, returning how much was written.
+    ///
+    /// `out` is only ever grown, never truncated, so a caller working through
+    /// span after span pays to zero a buffer once rather than once per span.
+    /// Only the bytes this reports are freshly inflated; anything after them
+    /// is whatever the last caller left behind.
+    pub fn extract_span_into(
+        &self,
+        blob: &[u8],
+        i: usize,
+        out: &mut Vec<u8>,
+        at: usize,
+    ) -> Result<usize> {
         let context = "resuming from checkpoint";
         let point = &self.checkpoints[i];
         let end = self
@@ -172,9 +182,10 @@ impl Index {
                 .map_err(|e| Error::io(context, e))?;
         }
 
-        let base = out.len();
-        out.resize(base + len, 0);
-        let span = &mut out[base..];
+        if out.len() < at + len {
+            out.resize(at + len, 0);
+        }
+        let span = &mut out[at..at + len];
         let mut in_pos = point.in_offset as usize;
         let mut filled = 0usize;
         while filled < len {
@@ -213,7 +224,7 @@ impl Index {
                 io::Error::other(format!("checkpoint {i} does not match its span checksum")),
             ));
         }
-        Ok(())
+        Ok(len)
     }
 
     pub fn write_to(&self, mut writer: impl Write) -> io::Result<()> {
@@ -470,9 +481,32 @@ mod tests {
         assert_spans_reproduce(&index, &blob, &data);
     }
 
+    /// The buffer is reused between spans and only ever grows, so what a span
+    /// reports is the only part of it that belongs to that span. A caller
+    /// reading past it would be handed whatever the last, longer span left.
     #[test]
-    fn a_second_gzip_member_gets_its_own_checkpoint() {
-        let first = sample_data(300 << 10);
+    fn a_span_owns_only_what_it_reports_writing() {
+        let data = sample_data(2 << 20);
+        let blob = gzip(&data);
+        let index = Index::build(&blob, 128 << 10).unwrap();
+
+        let mut buffer = vec![0xab; 4 << 20];
+        let stale = buffer.len();
+        let written = index
+            .extract_span_into(&blob, 1, &mut buffer, 0)
+            .expect("span");
+
+        let start = index.checkpoints[1].out_offset as usize;
+        assert_eq!(&buffer[..written], &data[start..start + written]);
+        assert_eq!(buffer.len(), stale, "a buffer this size needs no growing");
+        assert!(
+            buffer[written..].iter().all(|&byte| byte == 0xab),
+            "nothing past the span may be touched"
+        );
+    }
+
+    #[test]
+    fn a_second_gzip_member_gets_its_own_checkpoint() {        let first = sample_data(300 << 10);
         let second = sample_data(200 << 10);
         let mut blob = gzip(&first);
         let member_start = blob.len() as u64;


### PR DESCRIPTION
Workers claim a unit at a time, so the obvious question is whether they spend their time synchronising. They do not. The claim is already lock free -- a relaxed fetch_add over a shared index into a static slice, with the mutex touched only to record a failure. Instrumenting a chromium extraction put all 307 claims together at 0.1ms against ~11s of worker CPU, roughly a thousandth of a percent. Batching units or handing each worker a stealable deque would buy nothing measurable, so neither is here.

The same instrumentation found where the time actually went. Splitting the inflate phase showed 873-1227ms spent zeroing buffers, against 6769-7279ms of real decompression, over 3216 MiB inflated. Each unit called buffer.clear() and then resize(len, 0), so every unit paid to zero its buffer from length zero even though the allocation had been sitting there since the unit before. The bytes were then immediately overwritten by the inflate.

Spans are now written at an offset into a buffer that only ever grows, so the zeroing happens on a worker's high water mark rather than once per unit -- in practice once per worker. extract_span_into takes that offset and reports what it wrote, which becomes the contract: what a span reports is the only part of the buffer belonging to it, and run_span slices to that before reading a body rather than letting the buffer answer with what the widest unit before it left there. That slice is not reachable today, since the amount inflated is derived from the last entry of the same unit, but it costs nothing to state.

The win is larger than the memset alone, because pages freshly faulted in for each unit stay resident instead.

```
chromium, 22 layers, 46507 entries, musl, vs parallel extraction

tmpfs, n=14   cpu  min 14.173 -> 11.373  med 15.023 -> 12.909
              wall min  2.445 ->  0.842  med  3.297 ->  2.303
disk,  n=8    cpu  min 15.930 -> 14.623  med 17.121 -> 16.421
              wall min  3.990 ->  3.190  med  5.589 ->  3.551
```

Extracted trees compare identical, metadata and content, over all 46507 entries.