### PR TITLE
fix: keep the directory an opaque whiteout empties

### DIFF
--- a/source/src/entries.rs
+++ b/source/src/entries.rs
@@ -123,9 +123,7 @@ impl Table {
                 mtime: header.mtime().unwrap_or(0),
                 offset: entry.raw_file_position(),
                 size: entry.size(),
-                path: entry
-                    .path_bytes()
-                    .into_owned(),
+                path: without_trailing_slash(entry.path_bytes().into_owned()),
                 link: entry
                     .link_name_bytes()
                     .map(|link| link.into_owned())
@@ -221,6 +219,19 @@ fn write_bytes(out: &mut Vec<u8>, bytes: &[u8]) -> io::Result<()> {
     out.extend_from_slice(&len.to_le_bytes());
     out.extend_from_slice(bytes);
     Ok(())
+}
+
+/// `tar` spells a directory with a trailing slash, which would leave the plan
+/// holding `d/` for the directory and `d` for the same place as an ancestor of
+/// what is under it. Worse, `d/` sorts inside its own subtree, so clearing the
+/// subtree takes the directory with it.
+fn without_trailing_slash(mut path: Vec<u8>) -> Vec<u8> {
+    let kept = path.iter().rposition(|&byte| byte != b'/').map_or(0, |at| at + 1);
+    // A path of nothing but slashes names the root, which has no shorter form.
+    if kept > 0 {
+        path.truncate(kept);
+    }
+    path
 }
 
 fn short(what: &str) -> io::Error {
@@ -331,9 +342,39 @@ mod tests {
         assert_eq!(table.entries[2].link, b"dir/file");
     }
 
+    /// The plan keys its tree on these paths, and `d/` would sort inside its
+    /// own subtree rather than at the head of it.
     #[test]
-    fn a_table_survives_serialisation() {
-        let table = Table::build(&sample()[..]).expect("table");
+    fn directory_paths_are_recorded_without_their_trailing_slash() {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Directory);
+        header.set_mode(0o755);
+        header.set_size(0);
+        builder
+            .append_data(&mut header, "d/", std::io::empty())
+            .expect("dir");
+
+        let tar = builder.into_inner().expect("tar");
+        let table = Table::build(&tar[..]).expect("table");
+        assert_eq!(table.entries[0].path, b"d");
+    }
+
+    #[test]
+    fn a_path_of_nothing_but_slashes_is_left_alone() {
+        assert_eq!(without_trailing_slash(b"d/".to_vec()), b"d");
+        assert_eq!(without_trailing_slash(b"a/b//".to_vec()), b"a/b");
+        assert_eq!(without_trailing_slash(b"./".to_vec()), b".");
+        assert_eq!(without_trailing_slash(b"file".to_vec()), b"file");
+        assert_eq!(
+            without_trailing_slash(b"/".to_vec()),
+            b"/",
+            "the root has no shorter form to reduce to"
+        );
+    }
+
+    #[test]
+    fn a_table_survives_serialisation() {        let table = Table::build(&sample()[..]).expect("table");
         let mut bytes = Vec::new();
         table.write_to(&mut bytes).expect("write");
         assert_eq!(Table::read_from(&bytes[..]).expect("read"), table);

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -485,6 +485,21 @@ mod tests {
         assert!(!plan.is_shadowed(&d[1].digest, b"dir/.wh.a"));
     }
 
+    /// An opaque whiteout empties a directory; it does not delete it. The
+    /// directory sorts at the front of its own subtree, so clearing the
+    /// subtree used to take it as well.
+    #[test]
+    fn an_opaque_whiteout_leaves_the_directory_it_empties() {
+        assert_eq!(
+            dirs_of(vec![
+                layer(vec![dir("dir"), dir("dir/sub")]),
+                layer(vec![dir("dir"), file("dir/.wh..wh..opq")]),
+            ]),
+            ["dir"],
+            "the directory stays and only what was under it goes"
+        );
+    }
+
     #[test]
     fn an_opaque_whiteout_shadows_the_directory_it_names() {
         let (plan, d) = plan_of(vec![

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -1188,3 +1188,25 @@ fn every_route_agrees_when_a_layer_writes_through_a_symlink() {
     );
 }
 
+
+/// An opaque whiteout hides what is *in* a directory. The directory itself
+/// stays, and a route that resolves the tree up front has to keep it too.
+#[test]
+fn every_route_agrees_on_an_opaque_whiteout() {
+    assert_routes_agree(
+        "route-opaque",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "d/");
+                append_file(b, "d/one", b"one");
+                append_dir(b, "d/sub/");
+                append_file(b, "d/sub/two", b"two");
+            }),
+            tar_of(|b| {
+                append_dir(b, "d/");
+                append_file(b, "d/.wh..wh..opq", b"");
+            }),
+        ],
+    );
+}


### PR DESCRIPTION
The spec is explicit that `.wh..wh..opq` hides the children of the directory it sits in, not the directory: "an opaque whiteout entry is a file with the name `.wh..wh..opq` indicating that all siblings are hidden in the lower layer". The walking routes do this correctly, by listing the directory and removing each child. The plan did not, and deleted the directory along with everything under it.

The cause is that `tar` spells a directory with a trailing slash and we recorded the path as given. The plan keys its tree on those paths, so a directory arrived as `d/` while every path under it, and every reference to it as an ancestor, spelled it `d`. Clearing a subtree seeks from `d/` onwards, and `d/` sorts inside its own subtree rather than at the head of it, so the directory was swept up with its contents.

The same split had `directories()` wanting both `d` and `d/`, one from the entry and one as the ancestor of what was under it, and creating the same directory twice with two different modes. Which mode survived depended on the order the two were applied in.

Entry tables now record a directory without its trailing slash, which is the one place the two spellings meet. A path of nothing but slashes names the root and is left as it is.

Found by the route comparison added in the previous commit, on its first run: streaming kept the directory, the plan did not. Chromium extracts byte for byte identically before and after, metadata and content over all 46507 entries, so the bug was latent there -- its opaque whiteouts are followed by layers that put the directory back.