### PR TITLE
fix: apply a whiteout to the lower layers only

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -35,6 +35,7 @@ impl RootfsExtractor {
         // than a handful per entry.
         let mut path = PathBuf::new();
         let mut dst = PathBuf::new();
+        self.written.clear();
 
         for entry in entries {
             let mut entry = entry.io_context(|| format!("reading layer {layer}"))?;
@@ -65,7 +66,8 @@ impl RootfsExtractor {
                 // `target` borrows the buffer the new name has to go into.
                 let target = std::ffi::OsStr::from_bytes(target).to_owned();
                 dst.set_file_name(target);
-                if self.parents.contains_parent_of(&dst)? {
+                // A whiteout hides the layers below it, never the one it is in.
+                if !self.written.contains(&dst) && self.parents.contains_parent_of(&dst)? {
                     log!("Whiteout: removing /{}", relative_display(root, &dst));
                     if fsutil::remove_any(&dst)? {
                         self.parents.forget(&dst);
@@ -83,6 +85,11 @@ impl RootfsExtractor {
                 );
                 continue;
             }
+
+            // Recorded before the entry is placed rather than after, so that a
+            // whiteout later in the layer can tell this layer's work from the
+            // work of the layers below whatever the plan does with the entry.
+            self.written.insert(dst.clone());
 
             // A body a later layer replaces is written and then thrown away,
             // so the plan takes it out before any of that happens.
@@ -206,17 +213,42 @@ impl RootfsExtractor {
         if !self.parents.contains(dir)? {
             return Ok(());
         }
+        log!("Whiteout: clearing /{}", relative_display(root, dir));
+        self.clear_lower_layers(dir)?;
+        self.parents.forget(dir);
+        Ok(())
+    }
+
+    /// Removes everything under `dir` that this layer did not put there.
+    ///
+    /// A path this layer wrote stays, and so does the directory holding it,
+    /// which is why this walks down rather than clearing the level and
+    /// stopping.
+    fn clear_lower_layers(&mut self, dir: &Path) -> Result<()> {
         let entries = match fs::read_dir(dir) {
             Ok(entries) => entries,
             Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(err) => return Err(Error::io(format!("listing {}", dir.display()), err)),
         };
-        log!("Whiteout: clearing /{}", relative_display(root, dir));
+        let mut keep = Vec::new();
         for entry in entries {
             let entry = entry.io_context(|| format!("listing {}", dir.display()))?;
-            fsutil::remove_any(&entry.path())?;
+            let path = entry.path();
+            if self.written.contains(&path) {
+                if entry
+                    .file_type()
+                    .io_context(|| format!("inspecting {}", path.display()))?
+                    .is_dir()
+                {
+                    keep.push(path);
+                }
+                continue;
+            }
+            fsutil::remove_any(&path)?;
         }
-        self.parents.forget(dir);
+        for path in keep {
+            self.clear_lower_layers(&path)?;
+        }
         Ok(())
     }
 }

--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -13,6 +13,7 @@ mod spans;
 #[cfg(test)]
 mod tests;
 
+use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::os::unix::ffi::OsStrExt;
@@ -41,6 +42,9 @@ pub struct RootfsExtractor {
     deferred_modes: Vec<(PathBuf, u32)>,
     parents: fsutil::ParentCache,
     plan: plan::Plan,
+    /// What the layer currently being walked has placed. A whiteout hides the
+    /// layers below it, so it has to be able to tell them apart.
+    written: HashSet<PathBuf>,
 }
 
 impl RootfsExtractor {
@@ -52,6 +56,7 @@ impl RootfsExtractor {
             index_dir: index_dir.map(Utf8Path::to_owned),
             deferred_modes: Vec::new(),
             plan: plan::Plan::default(),
+            written: HashSet::new(),
         })
     }
 

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -240,10 +240,17 @@ fn replay(tables: &[Table]) -> BTreeMap<&[u8], Node> {
     for (l, table) in tables.iter().enumerate() {
         for (e, entry) in table.entries.iter().enumerate() {
             match whiteout(&entry.path) {
-                Some(Whiteout::Opaque(dir)) => remove_under(&mut tree, &dir, &mut bound),
+                // A whiteout hides the layers below it and never its own, so
+                // where the marker sits in the layer does not matter.
+                Some(Whiteout::Opaque(dir)) => remove_under(&mut tree, &dir, &mut bound, l),
                 Some(Whiteout::Named(target)) => {
-                    tree.remove(target.as_slice());
-                    remove_under(&mut tree, &target, &mut bound);
+                    if tree
+                        .get(target.as_slice())
+                        .is_some_and(|node| node.owner.0 < l)
+                    {
+                        tree.remove(target.as_slice());
+                    }
+                    remove_under(&mut tree, &target, &mut bound, l);
                 }
                 None => {
                     let node = Node {
@@ -269,7 +276,7 @@ fn replay(tables: &[Table]) -> BTreeMap<&[u8], Node> {
                         // Everything else clears the path first, which takes
                         // the tree underneath it as well.
                         _ => {
-                            remove_under(&mut tree, &entry.path, &mut bound);
+                            remove_under(&mut tree, &entry.path, &mut bound, l + 1);
                             tree.insert(&entry.path, node);
                         }
                     }
@@ -363,13 +370,13 @@ fn whiteout(path: &[u8]) -> Option<Whiteout> {
     Some(Whiteout::Named(named))
 }
 
-/// Drops every entry beneath `dir`, without touching a sibling whose name
-/// merely starts the same way.
+/// Drops every entry beneath `dir` that a layer before `below` put there,
+/// without touching a sibling whose name merely starts the same way.
 ///
 /// Every entry that is not a directory replays through here, so the bound it
 /// seeks from is built in a buffer the caller keeps rather than a fresh pair
 /// of allocations per path.
-fn remove_under(tree: &mut BTreeMap<&[u8], Node>, dir: &[u8], bound: &mut Vec<u8>) {
+fn remove_under(tree: &mut BTreeMap<&[u8], Node>, dir: &[u8], bound: &mut Vec<u8>, below: usize) {
     bound.clear();
     bound.extend_from_slice(dir);
     bound.push(b'/');
@@ -377,14 +384,16 @@ fn remove_under(tree: &mut BTreeMap<&[u8], Node>, dir: &[u8], bound: &mut Vec<u8
     // Everything under `dir` sorts from the bound onwards and is contiguous,
     // so the first path that is not under it ends the range.
     let mut doomed: Vec<&[u8]> = Vec::new();
-    for (path, _) in tree.range::<[u8], _>((
+    for (path, node) in tree.range::<[u8], _>((
         std::ops::Bound::Included(bound.as_slice()),
         std::ops::Bound::Unbounded,
     )) {
         if !path.starts_with(bound) {
             break;
         }
-        doomed.push(path);
+        if node.owner.0 < below {
+            doomed.push(path);
+        }
     }
     for path in doomed {
         tree.remove(path);

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -1210,3 +1210,87 @@ fn every_route_agrees_on_an_opaque_whiteout() {
         ],
     );
 }
+
+/// Runs the fixture by each route and hands the resulting rootfs to `check`.
+///
+/// Routes agreeing with each other is not the same as either being right, so a
+/// conformance case says what the tree must hold rather than only that the
+/// routes match.
+fn for_each_route(
+    name: &str,
+    routes: &[Route],
+    layers: &[Vec<u8>],
+    check: impl Fn(Route, &Utf8Path),
+) {
+    for &route in routes {
+        let root = scratch(&format!("{name}-{route:?}"));
+        let rootfs = extract_by(route, &root, layers)
+            .unwrap_or_else(|err| panic!("{name}: {route:?} failed to extract: {err}"));
+        check(route, &rootfs);
+        let _ = fsutil::force_remove_dir_all(root.as_std_path());
+    }
+}
+
+/// The spec's own example: an opaque whiteout is "applied first, before
+/// creating the new version of `a/b`, regardless of the ordering in which the
+/// whiteout file was encountered". Here it is encountered last.
+#[test]
+fn an_opaque_whiteout_applies_before_the_entries_beside_it() {
+    for_each_route(
+        "opq-ordering",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "a/");
+                append_dir(b, "a/b/");
+                append_dir(b, "a/b/c/");
+                append_file(b, "a/b/c/bar", b"bar");
+            }),
+            tar_of(|b| {
+                append_dir(b, "a/");
+                append_dir(b, "a/b/");
+                append_dir(b, "a/b/c/");
+                append_file(b, "a/b/c/foo", b"foo");
+                append_file(b, "a/.wh..wh..opq", b"");
+            }),
+        ],
+        |route, rootfs| {
+            assert!(
+                !rootfs.join("a/b/c/bar").exists(),
+                "{route:?}: the lower layer's file is hidden"
+            );
+            assert_eq!(
+                fs::read_to_string(rootfs.join("a/b/c/foo")).expect("foo"),
+                "foo",
+                "{route:?}: the marker's own layer is not hidden by it"
+            );
+        },
+    );
+}
+
+/// "Files that are present in the same layer as a whiteout file can only be
+/// hidden by whiteout files in subsequent layers."
+#[test]
+fn a_whiteout_does_not_hide_its_own_layer() {
+    for_each_route(
+        "wh-same-layer",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "d/");
+                append_file(b, "d/gone", b"lower");
+            }),
+            tar_of(|b| {
+                append_file(b, "d/gone", b"upper");
+                append_file(b, "d/.wh.gone", b"");
+            }),
+        ],
+        |route, rootfs| {
+            assert_eq!(
+                fs::read_to_string(rootfs.join("d/gone")).expect("gone"),
+                "upper",
+                "{route:?}: the whiteout hides the lower layer, not its own"
+            );
+        },
+    );
+}


### PR DESCRIPTION
Two clauses of the spec say the same thing from different directions. "Files that are present in the same layer as a whiteout file can only be hidden by whiteout files in subsequent layers." And, for the opaque marker, it "is applied first, before creating the new version of a/b, regardless of the ordering in which the whiteout file was encountered", with a worked example that puts the marker last in the layer.

We honoured neither. A whiteout removed whatever was at the path and an opaque one emptied the directory, without regard for which layer had put the contents there, so a marker sitting after its own layer's entries deleted them. umoci keeps a per-layer set of touched paths for exactly this, and calls it the upperdir.

Both clauses come out of one rule: a whiteout may only remove entries a lower layer put there. Once that holds, where the marker sits within its layer stops mattering, which is what the second clause is asking for.

The plan already knew, since every node records the layer and entry that put it there, so this is a comparison against the layer being replayed. The walking routes had nothing to compare against and now record what the layer has placed as they go. An opaque whiteout walks down instead of clearing one level, because a directory holding something this layer wrote has to survive even though the directory itself came from below.

Entries are recorded before they are placed rather than after, so the rule holds the same way whether or not the plan has already decided to skip the entry.

The cost is a path clone and a hash insert per entry on the walking routes, and one comparison per node in the plan replay. Measured on chromium, min and median of interleaved runs:

```
streaming, n=14   cpu 7.302 -> 7.393 min, 7.471 -> 7.494 med
indexed,   n=14   cpu 8.766 -> 8.874 min, 9.390 -> 9.480 med
```

So about 1% on either route, against a correctness rule that cannot be checked any more cheaply. Peak memory grows by one layer's worth of paths, freed at the layer boundary.

Chromium extracts byte for byte identically, metadata and content over all 46507 entries: no real layer there whiteouts its own work.