### PR TITLE
fix: refuse a whiteout that names nothing

### DIFF
--- a/source/src/error.rs
+++ b/source/src/error.rs
@@ -45,6 +45,11 @@ pub enum Error {
         layer: String,
         path: String,
     },
+    /// A whiteout entry with no basename after the `.wh.` prefix.
+    InvalidWhiteout {
+        layer: String,
+        path: String,
+    },
     /// The container had no command: the image sets neither `Entrypoint` nor `Cmd`.
     NoCommand,
     /// A launcher symlink could not find the runfiles tree holding its image.
@@ -114,6 +119,10 @@ impl fmt::Display for Error {
             Error::UnsafeEntry { layer, path } => write!(
                 f,
                 "layer {layer} contains entry {path:?} that escapes the root filesystem"
+            ),
+            Error::InvalidWhiteout { layer, path } => write!(
+                f,
+                "layer {layer} contains whiteout entry {path:?} that names nothing to remove"
             ),
             Error::NoCommand => write!(
                 f,

--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -63,6 +63,15 @@ impl RootfsExtractor {
                 continue;
             }
             if let Some(target) = name.strip_prefix(WHITEOUT_PREFIX.as_bytes()) {
+                // `.wh.` with nothing after it names nothing to remove, and
+                // taking it as a name would leave it pointing at the directory
+                // the marker sits in.
+                if target.is_empty() {
+                    return Err(Error::InvalidWhiteout {
+                        layer: layer.to_string(),
+                        path: path.display().to_string(),
+                    });
+                }
                 // `target` borrows the buffer the new name has to go into.
                 let target = std::ffi::OsStr::from_bytes(target).to_owned();
                 dst.set_file_name(target);

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -200,6 +200,11 @@ fn placeable(tree: &BTreeMap<&[u8], Node>, tables: &[Table]) -> Option<Work> {
     };
     for (path, node) in tree {
         let (layer, entry) = node.owner;
+        // A `.wh.` naming nothing is invalid and the walk rejects it, so the
+        // plan must not quietly place it as an ordinary file instead.
+        if basename(path) == WHITEOUT_PREFIX {
+            return None;
+        }
         match node.kind {
             Kind::Directory | Kind::Unsupported => continue,
             Kind::Sparse => return None,
@@ -319,8 +324,7 @@ fn directories(tree: &BTreeMap<&[u8], Node>) -> Vec<(Vec<u8>, u32)> {
 }
 
 /// Every strict ancestor of `path`, shallowest first.
-fn ancestors(path: &[u8]) -> impl Iterator<Item = &[u8]> {
-    path.iter()
+fn ancestors(path: &[u8]) -> impl Iterator<Item = &[u8]> {    path.iter()
         .enumerate()
         .filter(|(_, byte)| **byte == b'/')
         .map(move |(at, _)| &path[..at])
@@ -344,6 +348,13 @@ enum Whiteout {
     Opaque(Vec<u8>),
     /// `.wh.name`: hides the one path it names.
     Named(Vec<u8>),
+}
+
+fn basename(path: &[u8]) -> &[u8] {
+    match path.iter().rposition(|&byte| byte == b'/') {
+        Some(at) => &path[at + 1..],
+        None => path,
+    }
 }
 
 fn whiteout(path: &[u8]) -> Option<Whiteout> {
@@ -554,6 +565,14 @@ mod tests {
             !plan.is_shadowed(&d[0].digest, b"target"),
             "the copy the link was made against has to be placed"
         );
+    }
+
+    /// The walk refuses a `.wh.` that names nothing, so the plan must not
+    /// place it as an ordinary file and reach a different answer.
+    #[test]
+    fn a_whiteout_naming_nothing_is_not_placeable() {
+        let (plan, _) = plan_of(vec![layer(vec![dir("d"), file("d/.wh.")])]);
+        assert!(plan.work().is_none());
     }
 
     #[test]

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -1294,3 +1294,39 @@ fn a_whiteout_does_not_hide_its_own_layer() {
         },
     );
 }
+
+/// "A `.wh.` file, without a basename to delete, is invalid and
+/// implementations SHOULD return an error when encountering such an entry."
+/// Taking the empty name at face value pointed it at the directory the marker
+/// sits in, which was then removed.
+#[test]
+fn a_whiteout_naming_nothing_is_refused() {
+    // The span route is not among them: the plan refuses to place the entry,
+    // which drops the image to the walk, and the walk is what reports it.
+    for route in [Route::Streaming, Route::Planned] {
+        let root = scratch(&format!("bare-wh-{route:?}"));
+        let err = extract_by(
+            route,
+            &root,
+            &[
+                tar_of(|b| {
+                    append_dir(b, "d/");
+                    append_file(b, "d/keep", b"keep");
+                }),
+                tar_of(|b| append_file(b, "d/.wh.", b"")),
+            ],
+        )
+        .expect_err("a whiteout naming nothing must be refused");
+
+        assert!(
+            matches!(err, Error::InvalidWhiteout { .. }),
+            "{route:?}: expected an invalid whiteout, got {err:?}"
+        );
+        assert!(
+            root.join("rootfs/d/keep").exists(),
+            "{route:?}: the directory the marker sits in is not the target"
+        );
+
+        let _ = fsutil::force_remove_dir_all(root.as_std_path());
+    }
+}


### PR DESCRIPTION
"A `.wh.` file, without a basename to delete, is invalid and implementations SHOULD return an error when encountering such an entry."

We took the empty name at face value. Stripping the prefix left nothing, and setting that as the file name resolved back to the directory the marker sits in, so an entry called `d/.wh.` removed `d` and everything in it. Confined to the rootfs, and a layer may legitimately delete that directory, so this is a correctness wart rather than an escape -- but it is the opposite of what the entry asks for, which is nothing.

The two routes also disagreed. The plan read the same entry as a regular file called `.wh.` and would have created it, so an image extracted one way lost a directory and the other way gained a file. The walk now reports it, and the plan refuses to place it so that the image drops to the walk and gets the same answer rather than a quieter wrong one.

Tested through the routes that can reach it, and at the plan for the refusal. Chromium is unaffected, metadata and content identical over all 46507 entries.