### PR TITLE
fix: keep a path a layer names twice

### DIFF
--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -114,7 +114,7 @@ impl Plan {
         let mut bytes = 0u64;
         for (l, table) in tables.iter().enumerate() {
             let mut doomed = HashSet::new();
-            for (e, entry) in table.entries.iter().enumerate() {
+            for entry in table.entries.iter() {
                 // Only bodies are worth skipping, and a whiteout marker has to
                 // reach the extractor or nothing gets removed.
                 if !entry.kind.is_file() || whiteout(&entry.path).is_some() {
@@ -123,9 +123,12 @@ impl Plan {
                 if linked.contains(entry.path.as_slice()) {
                     continue;
                 }
+                // Whether the layer wins the path, not whether this entry
+                // does: a layer that names one path twice is skipped by path,
+                // so shadowing the loser would take the winner with it.
                 let survives = tree
                     .get(entry.path.as_slice())
-                    .is_some_and(|node| node.owner == (l, e));
+                    .is_some_and(|node| node.owner.0 == l);
                 if !survives {
                     bytes += entry.size;
                     doomed.insert(entry.path.clone());
@@ -486,6 +489,14 @@ mod tests {
         assert!(plan.is_shadowed(&d[0].digest, b"a"));
         assert!(!plan.is_shadowed(&d[0].digest, b"keep"));
         assert!(!plan.is_shadowed(&d[1].digest, b"a"), "the winner stays");
+    }
+
+    /// Shadowing is recorded by path, so a layer naming one path twice would
+    /// mark it doomed for the copy that loses and skip the copy that wins.
+    #[test]
+    fn a_path_a_layer_names_twice_is_not_shadowed_in_that_layer() {
+        let (plan, d) = plan_of(vec![layer(vec![file("twice"), file("twice")])]);
+        assert!(!plan.is_shadowed(&d[0].digest, b"twice"));
     }
 
     #[test]

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -1514,3 +1514,39 @@ fn a_hard_link_to_a_symlink_links_the_symlink() {
         },
     );
 }
+
+/// The spec says a layer "MUST NOT include duplicate entries for file paths",
+/// but says nothing about what to do with one that does. Whatever we do, the
+/// routes have to do the same thing.
+#[test]
+fn every_route_agrees_on_a_duplicated_path() {
+    assert_routes_agree(
+        "route-duplicates",
+        &Route::ALL,
+        &[tar_of(|b| {
+            append_dir(b, "d/");
+            append_file(b, "d/twice", b"first");
+            append_file(b, "d/twice", b"second");
+        })],
+    );
+}
+
+#[test]
+fn the_last_of_a_duplicated_path_is_the_one_kept() {
+    for_each_route(
+        "duplicates",
+        &Route::ALL,
+        &[tar_of(|b| {
+            append_dir(b, "d/");
+            append_file(b, "d/twice", b"first");
+            append_file(b, "d/twice", b"second");
+        })],
+        |route, rootfs| {
+            assert_eq!(
+                fs::read_to_string(rootfs.join("d/twice")).expect("twice"),
+                "second",
+                "{route:?}: the later entry wins, as a later layer would"
+            );
+        },
+    );
+}


### PR DESCRIPTION
The spec says a layer "MUST NOT include duplicate entries for file paths", and says nothing about what to do with one that does. We dropped the file entirely, which is the one answer nobody would want.

The plan records what a later layer replaces so the body is never written, and it records it by path. Replaying a layer that names one path twice leaves the tree holding the second entry, so the first is marked as replaced -- and the mark is the path, so it hid the second as well. The walk then skipped both and the file was missing. The span route places entries from the tree rather than by path and got it right, so the two disagreed.

Shadowing now asks whether the layer wins the path rather than whether one particular entry does. A layer that names a path twice writes it twice, the later winning, exactly as the walking routes already did. It is a wasted write in a case the spec forbids, which is a better trade than a lost file.

Found by the route comparison. Chromium is unaffected: the same 23475 files and 418 MiB are skipped as before, and the tree is identical over all 46507 entries.