### PR TITLE
fix: accept a layer entry naming the archive root

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -47,6 +47,21 @@ impl RootfsExtractor {
                     .as_ref(),
             );
 
+            // `./` names the rootfs, so there is nothing to place: the mode it
+            // carries is deferred like any other directory's, and a layer
+            // naming the root as anything but a directory is refused.
+            if fsutil::names_the_root(&path) {
+                if !entry.header().entry_type().is_dir() {
+                    return Err(Error::UnsafeEntry {
+                        layer: layer.to_string(),
+                        path: path.display().to_string(),
+                    });
+                }
+                let mode = entry.header().mode().unwrap_or(0o755) & 0o7777;
+                self.deferred_modes.push((root.to_path_buf(), mode));
+                continue;
+            }
+
             if !fsutil::resolve_under(root, &path, &mut dst) {
                 return Err(Error::UnsafeEntry {
                     layer: layer.to_string(),

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -1596,3 +1596,46 @@ fn a_sparse_file_keeps_its_hole() {
         assert_eq!(&body[1024..], &[7u8; 512], "{route:?}: and the data follows it");
     });
 }
+
+/// `tar -C dir .` puts the archive root in the layer as `./`, and the spec's
+/// own worked example lists it as the first entry. It names the rootfs rather
+/// than anything under it, which is not the same as escaping.
+#[test]
+fn every_route_agrees_on_a_layer_rooted_at_dot() {
+    assert_routes_agree(
+        "route-dot-root",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "./");
+                append_dir(b, "./etc/");
+                append_file(b, "./etc/config", b"config");
+                append_symlink(b, "./link", "etc/config");
+            }),
+            tar_of(|b| {
+                append_dir(b, "./");
+                append_file(b, "./etc/added", b"added");
+            }),
+        ],
+    );
+}
+
+#[test]
+fn a_layer_rooted_at_dot_extracts_its_entries() {
+    for_each_route(
+        "dot-root",
+        &Route::ALL,
+        &[tar_of(|b| {
+            append_dir(b, "./");
+            append_dir(b, "./etc/");
+            append_file(b, "./etc/config", b"config");
+        })],
+        |route, rootfs| {
+            assert_eq!(
+                fs::read_to_string(rootfs.join("etc/config")).expect("config"),
+                "config",
+                "{route:?}: an entry under the archive root still lands"
+            );
+        },
+    );
+}

--- a/source/src/fsutil.rs
+++ b/source/src/fsutil.rs
@@ -36,6 +36,22 @@ pub fn resolve_under(root: &Path, path: &Path, dst: &mut PathBuf) -> bool {
     components > 0
 }
 
+/// True when `path` names the rootfs itself rather than anything under it,
+/// which is what `tar -C dir .` writes as the first entry of a layer.
+///
+/// `..` is not this, however many `.` are around it: that names somewhere the
+/// layer has no business reaching.
+pub fn names_the_root(path: &Path) -> bool {
+    let mut components = path.components().peekable();
+    components.peek().is_some()
+        && components.all(|component| {
+            matches!(
+                component,
+                Component::Prefix(_) | Component::RootDir | Component::CurDir
+            )
+        })
+}
+
 /// Removes a tree even when directories were extracted without write permission.
 pub fn force_remove_dir_all(path: &Path) -> Result<()> {
     match fs::remove_dir_all(path) {
@@ -332,6 +348,25 @@ mod tests {
         assert_eq!(dst, PathBuf::from("/tmp/rootfs/usr/bin/env"));
         assert!(resolve_under(root, Path::new("etc"), &mut dst));
         assert_eq!(dst, PathBuf::from("/tmp/rootfs/etc"));
+    }
+
+    /// `tar -C dir .` writes the archive root into the layer, and the spec's
+    /// worked example lists it first. It is not an escape.
+    #[test]
+    fn the_archive_root_names_the_rootfs() {
+        assert!(names_the_root(Path::new(".")));
+        assert!(names_the_root(Path::new("./")));
+        assert!(names_the_root(Path::new("/")));
+        assert!(names_the_root(Path::new("./.")));
+    }
+
+    #[test]
+    fn nothing_that_climbs_out_names_the_rootfs() {
+        assert!(!names_the_root(Path::new("..")));
+        assert!(!names_the_root(Path::new("./..")));
+        assert!(!names_the_root(Path::new("../..")));
+        assert!(!names_the_root(Path::new("./etc")));
+        assert!(!names_the_root(Path::new("")), "an empty path names nothing");
     }
 
     #[test]


### PR DESCRIPTION
`tar -C dir .` writes the archive root into the layer as `./`, and the spec's worked example lists it as the first entry of the changeset. We rejected it as an escape and refused the whole image, so any layer built that way could not be extracted at all.

The path resolves to no components under the rootfs, which the resolver reports the same way it reports `..`, and the caller reads that as an attempt to get out. The two are not the same: `./` names the rootfs, and `..` names somewhere above it.

An entry naming the root is now recognised before the path is resolved. It carries a mode and nothing else, so the mode is deferred like any other directory's, and a layer naming the root as anything but a directory is still refused.

Found while building the umoci comparison in the next commit: the very first fixture, which was `tar -C src .` because that is how you make a tar, would not extract. Chromium never hit it because its layers do not carry the entry.