### PR TITLE
ci: run the end to end modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,32 @@ jobs:
           repository-cache: true
       - run: bazel test //...
         working-directory: ${{ matrix.module }}
+  # The end to end modules are kept apart from the unit tests: they reach the
+  # network for an image and for `umoci`, they run outside the Bazel sandbox,
+  # and they need user namespaces. A flake in one should not be read as the
+  # launcher being broken.
+  e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ["e2e/smoke", "e2e/conformance"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: "${{ github.workflow }}-test-${{ matrix.module }}"
+          repository-cache: true
+      # A rootless container is a user namespace, which Ubuntu confines by
+      # default. Older images have no such knob, hence the check.
+      - name: Permit unprivileged user namespaces
+        run: |
+          if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl --write kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+      - run: bazel test //...
+        working-directory: ${{ matrix.module }}
   # Publishes the same assets a release does, as workflow artifacts, so a change
   # can be tried out before it is released.
   artifacts:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,18 @@
 ## Development
 
 ```sh
-bazel test //...                    # rule tests and documentation freshness
-(cd source && bazel test //...)     # launcher unit tests
-(cd e2e/smoke && bazel test //...)  # end to end tests
-bazel run //docs:update             # regenerate docs/defs.md
+bazel test //...                          # rule tests and documentation freshness
+(cd source && bazel test //...)           # launcher unit tests
+(cd e2e/smoke && bazel test //...)        # end to end tests
+(cd e2e/conformance && bazel test //...)  # extraction compared against umoci
+bazel run //docs:update                   # regenerate docs/defs.md
+```
+
+The end to end modules run rootless containers, so they need unprivileged user
+namespaces. Distributions that confine those will refuse:
+
+```sh
+sudo sysctl --write kernel.apparmor_restrict_unprivileged_userns=0
 ```
 
 ## Releasing

--- a/e2e/conformance/BUILD.bazel
+++ b/e2e/conformance/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 alias(
     name = "umoci",
     actual = select({
-        "@platforms//cpu:arm64": "@umoci_linux_arm64//file",
+        "@platforms//cpu:aarch64": "@umoci_linux_arm64//file",
         "@platforms//cpu:x86_64": "@umoci_linux_amd64//file",
     }),
 )

--- a/e2e/conformance/MODULE.bazel
+++ b/e2e/conformance/MODULE.bazel
@@ -15,7 +15,7 @@ local_path_override(
 )
 
 bazel_dep(name = "rules_shell", version = "0.8.0")
-bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "platforms", version = "1.1.0")
 
 # umoci is the reference implementation the extracted trees are compared
 # against. Pinned by digest from the release's own `umoci.sha256sum`.


### PR DESCRIPTION
The workflow tested `.` and `source`. Neither end to end module ran anywhere, so the smoke tests and the umoci comparison only ever ran when somebody remembered to, which for a conformance suite makes it an audit rather than a guard against regressions.

They run as their own job rather than as two more entries in the existing matrix, because what they need is different in kind: the network, for an image and for `umoci`; no Bazel sandbox; and user namespaces. Keeping them apart means a flake in one is not read as the launcher being broken, and `fail-fast` is off so one module failing does not hide the state of the other.

A rootless container is a user namespace, and Ubuntu confines those by default from 23.10 on, so the job clears the restriction before testing. The check for the knob is for images old enough not to have it.

Both modules were run from a clean clone rather than from a warm tree, which is what turned up the `platforms` version being pinned a minor behind the rest of the repo and the `arm64` constraint being spelled differently here than everywhere else. Both are now consistent.

amd64 only. The arm64 `umoci` pin is still unexercised, and the runners for it are a separate question to whether these run at all.