### PR TITLE
build: keep the root module out of the sibling modules

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,5 @@
+# Bazel modules of their own, each tested from its own directory. Without this
+# the root module's `//...` descends into their convenience symlinks, which
+# point back here.
+source
+e2e

--- a/.github/workflows/make_release_archive.sh
+++ b/.github/workflows/make_release_archive.sh
@@ -63,6 +63,7 @@ root="${stage}/${prefix}"
 # Development only, and `docs/BUILD.bazel` would drag in the `@stardoc` dev
 # dependency that consumers never fetch.
 rm -rf \
+    "${root}/.bazelignore" \
     "${root}/.bazelrc" \
     "${root}/.bazelversion" \
     "${root}/.devcontainer" \


### PR DESCRIPTION
`source` and `e2e/*` are Bazel modules of their own, tested from their own directories. Once either had been built, the root module's `//...` walked into the convenience symlinks they leave behind, which point back here, and reported infinite symlink expansion for every one it found.

Harmless, in that the errors are skipped and the tests still pass, but they are noise on every local run and they hide a real one.

Stripped from release archives along with the other development only files: it names two directories the archive does not carry.