### PR TITLE
fix: resolve entry paths the same way on every route

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -33,6 +33,7 @@ impl RootfsExtractor {
         let mut buffer = vec![0u8; CHUNK_BYTES];
         // Reused for every entry, so a layer costs two path allocations rather
         // than a handful per entry.
+        let mut relative = Vec::new();
         let mut path = PathBuf::new();
         let mut dst = PathBuf::new();
         self.written.clear();
@@ -58,7 +59,7 @@ impl RootfsExtractor {
             // `./` names the rootfs, so there is nothing to place: the mode it
             // carries is deferred like any other directory's, and a layer
             // naming the root as anything but a directory is refused.
-            if fsutil::names_the_root(&path) {
+            if fsutil::names_the_root(path.as_os_str().as_bytes()) {
                 if !entry.header().entry_type().is_dir() {
                     return Err(Error::UnsafeEntry {
                         layer: layer.to_string(),
@@ -70,12 +71,13 @@ impl RootfsExtractor {
                 continue;
             }
 
-            if !fsutil::resolve_under(root, &path, &mut dst) {
+            if !fsutil::canonical_entry_path(path.as_os_str().as_bytes(), &mut relative) {
                 return Err(Error::UnsafeEntry {
                     layer: layer.to_string(),
                     path: path.display().to_string(),
                 });
             }
+            fsutil::join_under(root, &relative, &mut dst);
 
             let name = dst.file_name().unwrap_or_default().as_bytes();
             if name == OPAQUE_WHITEOUT.as_bytes() {
@@ -126,7 +128,7 @@ impl RootfsExtractor {
             // A body a later layer replaces is written and then thrown away,
             // so the plan takes it out before any of that happens.
             if matches!(entry_type, EntryType::Regular | EntryType::Continuous)
-                && self.plan.is_shadowed(layer, path.as_os_str().as_bytes())
+                && self.plan.is_shadowed(layer, &relative)
             {
                 continue;
             }
@@ -202,10 +204,13 @@ impl RootfsExtractor {
                     let target = link_name(&entry, layer)?.ok_or_else(unsafe_entry)?;
                     // A hard link names an earlier entry of the same archive,
                     // so it is rooted at the rootfs like any other entry path.
-                    let mut source = PathBuf::new();
-                    if !fsutil::resolve_under(root, &target, &mut source) {
+                    let target = target.as_os_str().as_bytes();
+                    let mut canonical = Vec::new();
+                    if !fsutil::canonical_entry_path(target, &mut canonical) {
                         return Err(unsafe_entry());
                     }
+                    let mut source = PathBuf::new();
+                    fsutil::join_under(root, &canonical, &mut source);
                     if !self.parents.contains_parent_of(&source)? {
                         return Err(unsafe_entry());
                     }

--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -16,7 +16,6 @@ mod tests;
 use std::collections::HashSet;
 use std::fs;
 use std::io;
-use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::sync::mpsc::sync_channel;
@@ -115,9 +114,7 @@ impl RootfsExtractor {
         let root = self.rootfs.clone();
         let mut path = PathBuf::new();
         for (relative, mode) in self.plan.directories() {
-            path.clear();
-            path.push(root.as_std_path());
-            path.push(std::ffi::OsStr::from_bytes(relative));
+            fsutil::join_under(root.as_std_path(), relative, &mut path);
             match fs::create_dir(&path) {
                 Ok(()) => {}
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -22,6 +22,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use camino::Utf8Path;
 
 use crate::entries::{Kind, Table};
+use crate::fsutil;
 use crate::image::{Descriptor, parse_digest};
 use crate::log::{log, warning};
 
@@ -96,7 +97,14 @@ impl Plan {
         Plan::resolve(layers, tables)
     }
 
-    fn resolve(layers: &[Descriptor], tables: Vec<Table>) -> Plan {
+    fn resolve(layers: &[Descriptor], mut tables: Vec<Table>) -> Plan {
+        // The paths the walk resolves and the paths the tables spell have to
+        // be one and the same, or the tree below describes an image nobody
+        // extracts.
+        if !canonicalise(&mut tables) {
+            return Plan::default();
+        }
+
         // A hard link is made against what is already on disk, so whatever it
         // names has to be placed even where a later layer replaces it. There
         // are single figures of these in a real image.
@@ -190,6 +198,43 @@ impl Plan {
     }
 }
 
+/// Rewrites every path in every table into the form the walk would resolve it
+/// to, so that `./etc/x` and `etc/x` are one path here as they are on disk.
+///
+/// False when a layer names something the walk refuses, or names the rootfs
+/// itself as anything but a directory. Both are errors, and the walk is where
+/// they are raised: planning only ever decides what need not be done.
+fn canonicalise(tables: &mut [Table]) -> bool {
+    let mut canonical = Vec::new();
+    for table in tables {
+        for entry in &mut table.entries {
+            if fsutil::names_the_root(&entry.path) {
+                if entry.kind != Kind::Directory {
+                    return false;
+                }
+                // The rootfs is already there and only its mode is deferred,
+                // so it is spelled the one way the tree can hold.
+                entry.path.clear();
+                entry.path.push(b'.');
+                continue;
+            }
+            if !fsutil::canonical_entry_path(&entry.path, &mut canonical) {
+                return false;
+            }
+            std::mem::swap(&mut entry.path, &mut canonical);
+            // A symlink target is followed from where the link stands rather
+            // than from the rootfs, so it is left as the layer spelled it.
+            if entry.kind == Kind::HardLink {
+                if !fsutil::canonical_entry_path(&entry.link, &mut canonical) {
+                    return false;
+                }
+                std::mem::swap(&mut entry.link, &mut canonical);
+            }
+        }
+    }
+    true
+}
+
 /// Groups the surviving entries for a caller that will place them directly.
 ///
 /// Returns `None` where the image holds something that only a walk of the
@@ -199,7 +244,10 @@ impl Plan {
 ///   be written from an offset and a length;
 /// - an entry that resolves through a symlink, where the path the layer spells
 ///   is not the path it lands on, and working that out means resolving against
-///   the tree as it is built.
+///   the tree as it is built;
+/// - a hard link naming something the final tree does not hold, or holds
+///   behind a symlink, where linking would follow the symlink to wherever it
+///   points and the walk checks that against the rootfs as it goes.
 fn placeable(tree: &BTreeMap<&[u8], Node>, tables: &[Table]) -> Option<Work> {
     let mut work = Work {
         files: vec![Vec::new(); tables.len()],
@@ -220,7 +268,13 @@ fn placeable(tree: &BTreeMap<&[u8], Node>, tables: &[Table]) -> Option<Work> {
             // A `BTreeMap` orders by path, so a link under another link is
             // already after it.
             Kind::Symlink => work.symlinks.push((layer as u32, entry as u32)),
-            Kind::HardLink => work.hard_links.push((layer as u32, entry as u32)),
+            Kind::HardLink => {
+                let target = tables[layer].entries[entry].link.as_slice();
+                if !tree.contains_key(target) || behind_a_link(tree, target) {
+                    return None;
+                }
+                work.hard_links.push((layer as u32, entry as u32))
+            }
         }
     }
     for (layer, entries) in work.files.iter_mut().enumerate() {
@@ -603,6 +657,91 @@ mod tests {
     fn an_absent_table_plans_nothing() {
         let plan = Plan::build(None, &[descriptor(0)]);
         assert!(!plan.is_shadowed(&descriptor(0).digest, b"anything"));
+    }
+
+    /// The tables spell a path as its layer does, while the walk resolves it.
+    /// A plan built on the raw spelling would not see that these are one file,
+    /// and the span route would then place both and collide.
+    mod one_path_however_it_is_spelled {
+        use super::*;
+
+        #[test]
+        fn a_later_layer_still_shadows_it() {
+            let (plan, d) = plan_of(vec![table(&["./etc/config"]), table(&["/etc/config"])]);
+            assert!(plan.is_shadowed(&d[0].digest, b"etc/config"));
+            assert!(!plan.is_shadowed(&d[1].digest, b"etc/config"));
+        }
+
+        #[test]
+        fn a_whiteout_still_hides_it() {
+            let (plan, d) = plan_of(vec![table(&["./dir/a"]), table(&["dir/.wh.a"])]);
+            assert!(plan.is_shadowed(&d[0].digest, b"dir/a"));
+        }
+
+        #[test]
+        fn the_directory_it_lives_in_is_created_once() {
+            assert_eq!(
+                dirs_of(vec![
+                    layer(vec![dir("./etc"), file("./etc/a")]),
+                    layer(vec![dir("etc"), file("etc/b")]),
+                ]),
+                ["etc"]
+            );
+        }
+    }
+
+    /// Refusing an entry is the walk's job, so an image holding one is left to
+    /// it rather than planned around.
+    mod what_only_the_walk_can_judge {
+        use super::*;
+
+        #[test]
+        fn a_path_that_climbs_out_of_the_rootfs() {
+            let (plan, _) = plan_of(vec![table(&["../escaped"])]);
+            assert!(!plan.is_resolved());
+        }
+
+        #[test]
+        fn a_hard_link_naming_something_outside_the_rootfs() {
+            let mut link = of_kind("stolen", Kind::HardLink);
+            link.link = b"../../etc/passwd".to_vec();
+            let (plan, _) = plan_of(vec![layer(vec![link])]);
+            assert!(!plan.is_resolved());
+        }
+
+        /// Linking follows a symlink on the way to the target, out of the
+        /// rootfs if that is where it points. The walk checks that against the
+        /// tree it has built; the plan can only decline.
+        #[test]
+        fn a_hard_link_reaching_through_a_symlink() {
+            let mut link = of_kind("stolen", Kind::HardLink);
+            link.link = b"lnk/passwd".to_vec();
+            let (plan, _) = plan_of(vec![layer(vec![symlink("lnk", "/etc"), link])]);
+            assert!(plan.work().is_none());
+        }
+
+        #[test]
+        fn a_hard_link_naming_a_path_the_image_never_places() {
+            let mut link = of_kind("dangling", Kind::HardLink);
+            link.link = b"absent".to_vec();
+            let (plan, _) = plan_of(vec![layer(vec![link])]);
+            assert!(plan.work().is_none());
+        }
+
+        #[test]
+        fn the_rootfs_named_as_anything_but_a_directory() {
+            let (plan, _) = plan_of(vec![layer(vec![file(".")])]);
+            assert!(!plan.is_resolved());
+        }
+    }
+
+    /// `tar -C dir .` writes the rootfs itself into every layer, so planning
+    /// has to survive it.
+    #[test]
+    fn the_archive_root_is_planned_as_the_rootfs_itself() {
+        let (plan, _) = plan_of(vec![layer(vec![dir("./"), dir("etc"), file("etc/a")])]);
+        assert!(plan.is_resolved());
+        assert!(plan.work().is_some());
     }
 
     /// Replacing a directory with anything else takes the tree under it away,

--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -370,17 +370,19 @@ fn place_symlink(root: &Path, entry: &Entry) -> Result<()> {
 fn place_hard_link(root: &Path, entry: &Entry) -> Result<()> {
     let mut path = PathBuf::new();
     resolve(root, &mut path, entry);
+    // The plan placed the target itself and checked that nothing on the way to
+    // it is a symlink, so this reaches the copy it named rather than following
+    // a link out of the rootfs.
     let mut source = PathBuf::new();
-    source.push(root);
-    source.push(std::ffi::OsStr::from_bytes(&entry.link));
+    crate::fsutil::join_under(root, &entry.link, &mut source);
     fs::hard_link(&source, &path)
         .io_context(|| format!("linking {:?}", String::from_utf8_lossy(&entry.path)))
 }
 
+/// Entry paths reach here in the one form every route agrees on, checked by
+/// the plan, so joining them cannot leave the rootfs.
 fn resolve(root: &Path, path: &mut PathBuf, entry: &Entry) {
-    path.clear();
-    path.push(root);
-    path.push(std::ffi::OsStr::from_bytes(&entry.path));
+    crate::fsutil::join_under(root, &entry.path, path);
 }
 
 fn verify(layer: &Layer) -> Result<()> {

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -845,6 +845,17 @@ fn append_file_moded(builder: &mut tar::Builder<Vec<u8>>, path: &str, body: &[u8
     builder.append_data(&mut header, path, body).expect("file");
 }
 
+/// A hostile layer has to be written by hand: `tar::Header` will not spell a
+/// path with `..` in it at all, and a real one is not built by this crate.
+fn append_file_named(builder: &mut tar::Builder<Vec<u8>>, name: &[u8], body: &[u8]) {
+    let mut header = tar::Header::new_gnu();
+    header.set_mode(0o644);
+    header.set_size(body.len() as u64);
+    header.as_gnu_mut().expect("gnu header").name[..name.len()].copy_from_slice(name);
+    header.set_cksum();
+    builder.append(&header, body).expect("file");
+}
+
 fn append_of_type(builder: &mut tar::Builder<Vec<u8>>, path: &str, entry_type: EntryType) {
     let mut header = tar::Header::new_gnu();
     header.set_entry_type(entry_type);
@@ -969,14 +980,12 @@ impl Route {
     const ALL: [Route; 3] = [Route::Streaming, Route::Planned, Route::Spans];
 }
 
-/// Applies `layers` by the given route, installing exactly the sidecars that
-/// route needs.
-fn extract_by(
+/// Installs `layers` as blobs, with exactly the sidecars `route` reads.
+fn install_for(
     route: Route,
     root: &Utf8Path,
     layers: &[Vec<u8>],
-    strict_xattrs: bool,
-) -> Result<Utf8PathBuf> {
+) -> (Utf8PathBuf, Vec<Descriptor>) {
     let index_dir = root.join("indexes");
     fs::create_dir_all(&index_dir).expect("index dir");
 
@@ -1000,6 +1009,18 @@ fn extract_by(
         }
         descriptors.push(descriptor);
     }
+    (index_dir, descriptors)
+}
+
+/// Applies `layers` by the given route, installing exactly the sidecars that
+/// route needs.
+fn extract_by(
+    route: Route,
+    root: &Utf8Path,
+    layers: &[Vec<u8>],
+    strict_xattrs: bool,
+) -> Result<Utf8PathBuf> {
+    let (index_dir, descriptors) = install_for(route, root, layers);
 
     // `install_blob` rewrites index.json each time, so the layout is opened
     // once every blob is in place.
@@ -1127,9 +1148,87 @@ fn assert_routes_agree(name: &str, routes: &[Route], layers: &[Vec<u8>]) {
     }
 }
 
+/// Applies `layers` by every route and fails unless each of them refuses the
+/// image.
+///
+/// No route is held to a plan shape here: an image the plan will not resolve
+/// falls back to the walk, and being refused there is the point.
+fn assert_routes_refuse(name: &str, layers: &[Vec<u8>]) {
+    for route in Route::ALL {
+        let root = scratch(&format!("{name}-{route:?}"));
+        let (index_dir, descriptors) = install_for(route, &root, layers);
+        let layout = Layout::open(&root).expect("layout");
+        let rootfs = root.join("rootfs");
+        let dir = match route {
+            Route::Streaming => None,
+            Route::Planned | Route::Spans => Some(index_dir.as_path()),
+        };
+
+        let mut extractor = RootfsExtractor::new(&rootfs, dir, true).expect("extractor");
+        let err = extractor
+            .plan(&descriptors)
+            .and_then(|()| extractor.apply(&layout, &descriptors))
+            .expect_err(&format!("{name}: {route:?} extracted what it must refuse"));
+        assert!(
+            matches!(err, Error::UnsafeEntry { .. }),
+            "{name}: {route:?} expected an unsafe entry, got {err:?}"
+        );
+        assert!(
+            !root.join("escaped").exists(),
+            "{name}: {route:?} wrote outside the rootfs"
+        );
+
+        let _ = fsutil::force_remove_dir_all(root.as_std_path());
+    }
+}
+
+/// The sidecars describe the same hostile layer, and the routes that read them
+/// join the paths those sidecars hold straight onto the rootfs.
 #[test]
-fn every_route_agrees_on_a_layered_image() {
+fn no_route_places_an_entry_that_climbs_out_of_the_rootfs() {
+    assert_routes_refuse(
+        "route-escape",
+        &[tar_of(|b| {
+            append_dir(b, "etc/");
+            append_file_named(b, b"etc/../../escaped", b"nope");
+        })],
+    );
+}
+
+#[test]
+fn no_route_places_a_hard_link_that_climbs_out_of_the_rootfs() {
+    assert_routes_refuse(
+        "route-hard-link-escape",
+        &[tar_of(|b| {
+            append_file(b, "keep", b"keep");
+            append_hard_link(b, "stolen", "../../etc/passwd");
+        })],
+    );
+}
+
+/// One file spelled two ways is one file. A route that thought otherwise
+/// would place both copies, and the span route would then collide on a path
+/// the plan promised it owned.
+#[test]
+fn every_route_agrees_when_layers_spell_one_path_differently() {
     assert_routes_agree(
+        "route-spelling",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "./etc/");
+                append_file(b, "./etc/config", b"first");
+            }),
+            tar_of(|b| {
+                append_dir(b, "etc/");
+                append_file(b, "etc/config", b"second");
+            }),
+        ],
+    );
+}
+
+#[test]
+fn every_route_agrees_on_a_layered_image() {    assert_routes_agree(
         "route-layered",
         &Route::ALL,
         &[

--- a/source/src/fsutil.rs
+++ b/source/src/fsutil.rs
@@ -1,39 +1,69 @@
 //! Filesystem helpers shared by extraction and cleanup.
 
 use std::collections::BTreeSet;
+use std::ffi::OsStr;
 use std::fs;
 use std::io;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use crate::error::{IoContext, Result};
 
-/// Rebuilds `dst` as `root` joined with the safe components of `path`, or
-/// returns false when the entry tries to escape (absolute paths are rooted at
-/// the rootfs, `..` is never allowed) or names nothing at all.
+const CURRENT_DIR: &[u8] = b".";
+const PARENT_DIR: &[u8] = b"..";
+
+/// The components `path` names, with the ones that name nowhere dropped.
+fn components(path: &[u8]) -> impl Iterator<Item = &[u8]> {
+    path.split(|&byte| byte == b'/')
+        .filter(|component| !component.is_empty() && *component != CURRENT_DIR)
+}
+
+/// The components an entry names under the rootfs, or `None` when it names
+/// nothing at all or climbs out (absolute paths are rooted at the rootfs,
+/// `..` is never allowed).
 ///
-/// The destination is what every caller actually wants, so it is built
-/// directly into a buffer they own: a layer is tens of thousands of entries,
-/// and a component list per entry is tens of thousands of allocations that
-/// only exist to be joined back together.
-pub fn resolve_under(root: &Path, path: &Path, dst: &mut PathBuf) -> bool {
+/// A layer spells one file several ways: `etc/passwd`, `./etc/passwd` and
+/// `/etc/passwd` all name it. Every route has to agree on which, or a path a
+/// later layer replaces is not recognised as the same path.
+pub fn safe_components(path: &[u8]) -> Option<impl Iterator<Item = &[u8]>> {
+    let mut names_something = false;
+    for component in components(path) {
+        if component == PARENT_DIR {
+            return None;
+        }
+        names_something = true;
+    }
+    names_something.then(|| components(path))
+}
+
+/// Rebuilds `path` in `out` as the single form every route agrees on, or
+/// returns false when the entry names nothing or tries to escape.
+///
+/// The result is what the caller actually wants, so it is built directly into
+/// a buffer they own: a layer is tens of thousands of entries, and a component
+/// list per entry is tens of thousands of allocations that only exist to be
+/// joined back together.
+pub fn canonical_entry_path(path: &[u8], out: &mut Vec<u8>) -> bool {
+    out.clear();
+    let Some(components) = safe_components(path) else {
+        return false;
+    };
+    for component in components {
+        if !out.is_empty() {
+            out.push(b'/');
+        }
+        out.extend_from_slice(component);
+    }
+    true
+}
+
+/// Rebuilds `dst` as `root` joined with a path [`canonical_entry_path`] has
+/// already accepted.
+pub fn join_under(root: &Path, relative: &[u8], dst: &mut PathBuf) {
     dst.clear();
     dst.push(root);
-    let mut components = 0;
-    for component in path.components() {
-        match component {
-            Component::Prefix(_) | Component::RootDir | Component::CurDir => continue,
-            Component::ParentDir => return false,
-            Component::Normal(part) => {
-                if part.is_empty() {
-                    continue;
-                }
-                dst.push(part);
-                components += 1;
-            }
-        }
-    }
-    components > 0
+    dst.push(OsStr::from_bytes(relative));
 }
 
 /// True when `path` names the rootfs itself rather than anything under it,
@@ -41,15 +71,8 @@ pub fn resolve_under(root: &Path, path: &Path, dst: &mut PathBuf) -> bool {
 ///
 /// `..` is not this, however many `.` are around it: that names somewhere the
 /// layer has no business reaching.
-pub fn names_the_root(path: &Path) -> bool {
-    let mut components = path.components().peekable();
-    components.peek().is_some()
-        && components.all(|component| {
-            matches!(
-                component,
-                Component::Prefix(_) | Component::RootDir | Component::CurDir
-            )
-        })
+pub fn names_the_root(path: &[u8]) -> bool {
+    !path.is_empty() && components(path).next().is_none()
 }
 
 /// Removes a tree even when directories were extracted without write permission.
@@ -298,30 +321,33 @@ mod tests {
     use super::*;
 
     fn resolved(path: &str) -> Option<String> {
-        let mut dst = PathBuf::new();
-        resolve_under(Path::new("/tmp/rootfs"), Path::new(path), &mut dst)
-            .then(|| dst.to_string_lossy().into_owned())
+        let mut canonical = Vec::new();
+        canonical_entry_path(path.as_bytes(), &mut canonical)
+            .then(|| String::from_utf8(canonical).expect("utf8"))
     }
 
     #[test]
     fn absolute_paths_are_rooted_at_the_rootfs() {
-        assert_eq!(resolved("/etc/passwd").as_deref(), Some("/tmp/rootfs/etc/passwd"));
+        assert_eq!(resolved("/etc/passwd").as_deref(), Some("etc/passwd"));
     }
 
     #[test]
     fn leading_dot_slash_is_stripped() {
-        assert_eq!(
-            resolved("./usr/bin/env").as_deref(),
-            Some("/tmp/rootfs/usr/bin/env")
-        );
+        assert_eq!(resolved("./usr/bin/env").as_deref(), Some("usr/bin/env"));
     }
 
     #[test]
     fn redundant_separators_are_collapsed() {
-        assert_eq!(
-            resolved("usr//bin///env").as_deref(),
-            Some("/tmp/rootfs/usr/bin/env")
-        );
+        assert_eq!(resolved("usr//bin///env").as_deref(), Some("usr/bin/env"));
+    }
+
+    /// The same file spelled three ways has to come out as one path, or the
+    /// plan cannot tell that a later layer replaces it.
+    #[test]
+    fn the_spellings_of_one_path_agree() {
+        assert_eq!(resolved("etc/passwd"), resolved("./etc/passwd"));
+        assert_eq!(resolved("etc/passwd"), resolved("/etc/passwd"));
+        assert_eq!(resolved("etc/passwd"), resolved("etc/./passwd"));
     }
 
     #[test]
@@ -342,11 +368,14 @@ mod tests {
     /// longer one's tail behind.
     #[test]
     fn a_reused_buffer_is_rebuilt_rather_than_appended_to() {
-        let root = Path::new("/tmp/rootfs");
+        let mut canonical = b"somewhere/else/entirely".to_vec();
+        assert!(canonical_entry_path(b"usr/bin/env", &mut canonical));
+        assert_eq!(canonical, b"usr/bin/env");
+        assert!(canonical_entry_path(b"etc", &mut canonical));
+        assert_eq!(canonical, b"etc");
+
         let mut dst = PathBuf::from("/somewhere/else/entirely");
-        assert!(resolve_under(root, Path::new("usr/bin/env"), &mut dst));
-        assert_eq!(dst, PathBuf::from("/tmp/rootfs/usr/bin/env"));
-        assert!(resolve_under(root, Path::new("etc"), &mut dst));
+        join_under(Path::new("/tmp/rootfs"), &canonical, &mut dst);
         assert_eq!(dst, PathBuf::from("/tmp/rootfs/etc"));
     }
 
@@ -354,19 +383,19 @@ mod tests {
     /// worked example lists it first. It is not an escape.
     #[test]
     fn the_archive_root_names_the_rootfs() {
-        assert!(names_the_root(Path::new(".")));
-        assert!(names_the_root(Path::new("./")));
-        assert!(names_the_root(Path::new("/")));
-        assert!(names_the_root(Path::new("./.")));
+        assert!(names_the_root(b"."));
+        assert!(names_the_root(b"./"));
+        assert!(names_the_root(b"/"));
+        assert!(names_the_root(b"./."));
     }
 
     #[test]
     fn nothing_that_climbs_out_names_the_rootfs() {
-        assert!(!names_the_root(Path::new("..")));
-        assert!(!names_the_root(Path::new("./..")));
-        assert!(!names_the_root(Path::new("../..")));
-        assert!(!names_the_root(Path::new("./etc")));
-        assert!(!names_the_root(Path::new("")), "an empty path names nothing");
+        assert!(!names_the_root(b".."));
+        assert!(!names_the_root(b"./.."));
+        assert!(!names_the_root(b"../.."));
+        assert!(!names_the_root(b"./etc"));
+        assert!(!names_the_root(b""), "an empty path names nothing");
     }
 
     #[test]


### PR DESCRIPTION
The walk resolved every entry path with `resolve_under`, which roots an absolute path at the rootfs and refuses `..`. The plan and the span route joined the paths their entry tables hold straight onto the rootfs instead, so nothing checked them: a layer naming `etc/../../escaped` was written outside the rootfs, and a hard link could name a target reached through a symlink pointing anywhere on the host.

The two also disagreed on what a path is. `./etc/x` and `etc/x` name one file to the walk and two to the plan, so a later layer did not shadow an earlier one and the span route placed both copies and collided on the second.

There is one rule now: `fsutil::canonical_entry_path` over bytes, with `resolve_under` folded into it and the walk, the plan and the span route all built on top. Tables are canonicalised as the plan reads them, and an image holding something only the walk can judge -- a path that climbs out, the rootfs named as anything but a directory, a hard link the final tree does not hold or holds behind a symlink -- is left unplanned so that the walk still refuses it.

The escape fixtures ran against the walk alone, which is why this survived; they now run against every route.