### PR TITLE
refactor: read whiteout markers in one place

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -14,9 +14,7 @@ use crate::log::{log, warning};
 use super::RootfsExtractor;
 use super::file::{prepare_directory, set_symlink_mtime, unpack_regular};
 use super::pipeline::CHUNK_BYTES;
-
-pub(super) const WHITEOUT_PREFIX: &str = ".wh.";
-pub(super) const OPAQUE_WHITEOUT: &str = ".wh..wh..opq";
+use super::whiteout::{self, Whiteout};
 
 impl RootfsExtractor {
     pub(super) fn unpack(&mut self, reader: &mut dyn Read, layer: &str) -> Result<()> {
@@ -79,35 +77,38 @@ impl RootfsExtractor {
             }
             fsutil::join_under(root, &relative, &mut dst);
 
-            let name = dst.file_name().unwrap_or_default().as_bytes();
-            if name == OPAQUE_WHITEOUT.as_bytes() {
-                dst.pop();
-                let dir = std::mem::take(&mut dst);
-                self.apply_opaque_whiteout(root, &dir)?;
-                dst = dir;
-                continue;
-            }
-            if let Some(target) = name.strip_prefix(WHITEOUT_PREFIX.as_bytes()) {
-                // `.wh.` with nothing after it names nothing to remove, and
-                // taking it as a name would leave it pointing at the directory
-                // the marker sits in.
-                if target.is_empty() {
+            match whiteout::of(&relative) {
+                Some(Whiteout::Opaque(dir)) => {
+                    let dir = match dir.is_empty() {
+                        // A marker at the top of the layer names the rootfs.
+                        true => root.to_path_buf(),
+                        false => {
+                            let mut at = PathBuf::new();
+                            fsutil::join_under(root, &dir, &mut at);
+                            at
+                        }
+                    };
+                    self.apply_opaque_whiteout(root, &dir)?;
+                    continue;
+                }
+                Some(Whiteout::Named(target)) => {
+                    fsutil::join_under(root, &target, &mut dst);
+                    // A whiteout hides the layers below it, never the one it is in.
+                    if !self.written.contains(&dst) && self.parents.contains_parent_of(&dst)? {
+                        log!("Whiteout: removing /{}", relative_display(root, &dst));
+                        if fsutil::remove_any(&dst)? {
+                            self.parents.forget(&dst);
+                        }
+                    }
+                    continue;
+                }
+                Some(Whiteout::Invalid) => {
                     return Err(Error::InvalidWhiteout {
                         layer: layer.to_string(),
                         path: path.display().to_string(),
                     });
                 }
-                // `target` borrows the buffer the new name has to go into.
-                let target = std::ffi::OsStr::from_bytes(target).to_owned();
-                dst.set_file_name(target);
-                // A whiteout hides the layers below it, never the one it is in.
-                if !self.written.contains(&dst) && self.parents.contains_parent_of(&dst)? {
-                    log!("Whiteout: removing /{}", relative_display(root, &dst));
-                    if fsutil::remove_any(&dst)? {
-                        self.parents.forget(&dst);
-                    }
-                }
-                continue;
+                None => {}
             }
 
             let entry_type = entry.header().entry_type();

--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -12,6 +12,7 @@ mod plan;
 mod spans;
 #[cfg(test)]
 mod tests;
+mod whiteout;
 
 use std::collections::HashSet;
 use std::fs;

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -26,11 +26,14 @@ use crate::fsutil;
 use crate::image::{Descriptor, parse_digest};
 use crate::log::{log, warning};
 
-const WHITEOUT_PREFIX: &[u8] = b".wh.";
-const OPAQUE_WHITEOUT: &[u8] = b".wh..wh..opq";
+use super::whiteout::{self, Whiteout};
 
 /// What `create_dir` would have given a directory nothing names.
 const DEFAULT_DIRECTORY_MODE: u32 = 0o755;
+
+/// The rootfs itself, which a layer names as `.` or `/` and which the tree
+/// holds the one way.
+const ROOT_ENTRY: &[u8] = b".";
 
 /// The entries each layer can skip, keyed by layer digest, and the directory
 /// tree they all need.
@@ -125,7 +128,7 @@ impl Plan {
             for entry in table.entries.iter() {
                 // Only bodies are worth skipping, and a whiteout marker has to
                 // reach the extractor or nothing gets removed.
-                if !entry.kind.is_file() || whiteout(&entry.path).is_some() {
+                if !entry.kind.is_file() || whiteout::of(&entry.path).is_some() {
                     continue;
                 }
                 if linked.contains(entry.path.as_slice()) {
@@ -215,7 +218,7 @@ fn canonicalise(tables: &mut [Table]) -> bool {
                 // The rootfs is already there and only its mode is deferred,
                 // so it is spelled the one way the tree can hold.
                 entry.path.clear();
-                entry.path.push(b'.');
+                entry.path.extend_from_slice(ROOT_ENTRY);
                 continue;
             }
             if !fsutil::canonical_entry_path(&entry.path, &mut canonical) {
@@ -257,7 +260,7 @@ fn placeable(tree: &BTreeMap<&[u8], Node>, tables: &[Table]) -> Option<Work> {
         let (layer, entry) = node.owner;
         // A `.wh.` naming nothing is invalid and the walk rejects it, so the
         // plan must not quietly place it as an ordinary file instead.
-        if basename(path) == WHITEOUT_PREFIX {
+        if matches!(whiteout::of(path), Some(Whiteout::Invalid)) {
             return None;
         }
         match node.kind {
@@ -305,7 +308,7 @@ fn replay(tables: &[Table]) -> BTreeMap<&[u8], Node> {
     let mut bound = Vec::new();
     for (l, table) in tables.iter().enumerate() {
         for (e, entry) in table.entries.iter().enumerate() {
-            match whiteout(&entry.path) {
+            match whiteout::of(&entry.path) {
                 // A whiteout hides the layers below it and never its own, so
                 // where the marker sits in the layer does not matter.
                 Some(Whiteout::Opaque(dir)) => remove_under(&mut tree, &dir, &mut bound, l),
@@ -318,7 +321,10 @@ fn replay(tables: &[Table]) -> BTreeMap<&[u8], Node> {
                     }
                     remove_under(&mut tree, &target, &mut bound, l);
                 }
-                None => {
+                // A marker naming nothing removes nothing. It stays an entry
+                // like any other, which is how `placeable` sees it and
+                // declines the image to the walk that refuses it.
+                None | Some(Whiteout::Invalid) => {
                     let node = Node {
                         kind: entry.kind,
                         owner: (l, e),
@@ -404,54 +410,22 @@ fn behind_a_link(tree: &BTreeMap<&[u8], Node>, path: &[u8]) -> bool {
     })
 }
 
-enum Whiteout {
-    /// `.wh..wh..opq`: hides everything the lower layers put in this directory.
-    Opaque(Vec<u8>),
-    /// `.wh.name`: hides the one path it names.
-    Named(Vec<u8>),
-}
-
-fn basename(path: &[u8]) -> &[u8] {
-    match path.iter().rposition(|&byte| byte == b'/') {
-        Some(at) => &path[at + 1..],
-        None => path,
-    }
-}
-
-fn whiteout(path: &[u8]) -> Option<Whiteout> {
-    let (dir, name) = match path.iter().rposition(|&b| b == b'/') {
-        Some(at) => (&path[..at], &path[at + 1..]),
-        None => (&path[..0], path),
-    };
-    if name == OPAQUE_WHITEOUT {
-        return Some(Whiteout::Opaque(dir.to_vec()));
-    }
-    let target = name.strip_prefix(WHITEOUT_PREFIX)?;
-    // `.wh.` with nothing after it names nothing.
-    if target.is_empty() {
-        return None;
-    }
-    // The marker sits in the middle of the path, so what it names has to be
-    // put back together rather than sliced out.
-    let mut named = Vec::with_capacity(dir.len() + 1 + target.len());
-    if !dir.is_empty() {
-        named.extend_from_slice(dir);
-        named.push(b'/');
-    }
-    named.extend_from_slice(target);
-    Some(Whiteout::Named(named))
-}
-
 /// Drops every entry beneath `dir` that a layer before `below` put there,
 /// without touching a sibling whose name merely starts the same way.
+///
+/// An empty `dir` is the rootfs itself, which every path is under. The rootfs
+/// is not removed with them: the walk empties the directory the marker names
+/// rather than deleting it.
 ///
 /// Every entry that is not a directory replays through here, so the bound it
 /// seeks from is built in a buffer the caller keeps rather than a fresh pair
 /// of allocations per path.
 fn remove_under(tree: &mut BTreeMap<&[u8], Node>, dir: &[u8], bound: &mut Vec<u8>, below: usize) {
     bound.clear();
-    bound.extend_from_slice(dir);
-    bound.push(b'/');
+    if !dir.is_empty() {
+        bound.extend_from_slice(dir);
+        bound.push(b'/');
+    }
 
     // Everything under `dir` sorts from the bound onwards and is contiguous,
     // so the first path that is not under it ends the range.
@@ -463,7 +437,7 @@ fn remove_under(tree: &mut BTreeMap<&[u8], Node>, dir: &[u8], bound: &mut Vec<u8
         if !path.starts_with(bound) {
             break;
         }
-        if node.owner.0 < below {
+        if node.owner.0 < below && *path != ROOT_ENTRY {
             doomed.push(path);
         }
     }
@@ -863,12 +837,27 @@ mod tests {
         assert_eq!(dirs, ["kept"]);
     }
 
+    /// The marker names the rootfs, which is not a path under it, so the tree
+    /// has no key to clear from and used to keep everything.
     #[test]
-    fn whiteout_names_are_recognised() {        assert!(matches!(whiteout(b"dir/.wh..wh..opq"), Some(Whiteout::Opaque(d)) if d == b"dir"));
-        assert!(matches!(whiteout(b".wh..wh..opq"), Some(Whiteout::Opaque(d)) if d.is_empty()));
-        assert!(matches!(whiteout(b"dir/.wh.name"), Some(Whiteout::Named(n)) if n == b"dir/name"));
-        assert!(matches!(whiteout(b".wh.name"), Some(Whiteout::Named(n)) if n == b"name"));
-        assert!(whiteout(b"dir/name").is_none());
-        assert!(whiteout(b"dir/.wh.").is_none());
+    fn an_opaque_whiteout_at_the_top_of_a_layer_clears_the_whole_tree() {
+        let (plan, d) = plan_of(vec![
+            table(&["a", "dir/b"]),
+            layer(vec![file(".wh..wh..opq"), file("kept")]),
+        ]);
+        assert!(plan.is_shadowed(&d[0].digest, b"a"));
+        assert!(plan.is_shadowed(&d[0].digest, b"dir/b"));
+        assert!(!plan.is_shadowed(&d[1].digest, b"kept"));
+    }
+
+    /// It empties the rootfs rather than removing it, so the mode a layer
+    /// gives the rootfs still stands.
+    #[test]
+    fn an_opaque_whiteout_at_the_top_of_a_layer_leaves_the_rootfs() {
+        let dirs = dirs_of(vec![
+            layer(vec![dir("."), dir("gone")]),
+            layer(vec![file(".wh..wh..opq")]),
+        ]);
+        assert_eq!(dirs, ["."]);
     }
 }

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -19,7 +19,7 @@ use crate::image::{Descriptor, Layout, hex_encode, parse_digest};
 use crate::zinfo;
 
 use super::RootfsExtractor;
-use super::entry::{OPAQUE_WHITEOUT, WHITEOUT_PREFIX, is_supported};
+use super::entry::is_supported;
 use super::pipeline::{
     CHUNK_BYTES, Chunk, ChunkReader, PIPELINE_DEPTH, buffer_pool, compression_of, read_and_hash,
 };
@@ -110,13 +110,6 @@ fn recycled_buffers_do_not_leak_the_previous_chunk() {
     // Draining a chunk hands its buffer back with the stale tail intact.
     let recycled = pool.take();
     assert_eq!(&recycled[..4], b"aaaa");
-}
-
-#[test]
-fn whiteout_names_are_recognised() {
-    assert!(OPAQUE_WHITEOUT.starts_with(WHITEOUT_PREFIX));
-    assert_eq!(".wh.foo".strip_prefix(WHITEOUT_PREFIX), Some("foo"));
-    assert_eq!("foo".strip_prefix(WHITEOUT_PREFIX), None);
 }
 
 const GZIP_LAYER: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
@@ -1325,6 +1318,27 @@ fn every_route_agrees_on_an_opaque_whiteout() {
             tar_of(|b| {
                 append_dir(b, "d/");
                 append_file(b, "d/.wh..wh..opq", b"");
+            }),
+        ],
+    );
+}
+
+/// The marker names the rootfs itself, which is not a path under it, so the
+/// plan had nothing to clear from and kept what the walk removed.
+#[test]
+fn every_route_agrees_on_an_opaque_whiteout_at_the_top_of_a_layer() {
+    assert_routes_agree(
+        "route-opaque-root",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "etc/");
+                append_file(b, "etc/gone", b"gone");
+                append_file(b, "gone", b"gone");
+            }),
+            tar_of(|b| {
+                append_file(b, ".wh..wh..opq", b"");
+                append_file(b, "kept", b"kept");
             }),
         ],
     );

--- a/source/src/extract/whiteout.rs
+++ b/source/src/extract/whiteout.rs
@@ -1,0 +1,80 @@
+//! The markers a layer uses to hide what the layers below it left behind.
+//!
+//! Both routes have to read them the same way: the plan decides what a marker
+//! removes from the tree it resolves, and the walk decides what it removes
+//! from the tree on disk. A marker only one of them recognised would leave the
+//! two describing different images.
+
+pub(super) const PREFIX: &[u8] = b".wh.";
+pub(super) const OPAQUE: &[u8] = b".wh..wh..opq";
+
+pub(super) enum Whiteout {
+    /// `.wh..wh..opq`: hides everything the lower layers put in this
+    /// directory. Empty when the marker sits at the top of the layer, which
+    /// names the rootfs itself.
+    Opaque(Vec<u8>),
+    /// `.wh.name`: hides the one path it names.
+    Named(Vec<u8>),
+    /// `.wh.` with nothing after it, which names nothing to remove. Taking it
+    /// as a name would leave it pointing at the directory the marker sits in.
+    Invalid,
+}
+
+/// What `path` marks for removal, or `None` when it is an ordinary entry.
+pub(super) fn of(path: &[u8]) -> Option<Whiteout> {
+    let (dir, name) = split(path);
+    if name == OPAQUE {
+        return Some(Whiteout::Opaque(dir.to_vec()));
+    }
+    let target = name.strip_prefix(PREFIX)?;
+    if target.is_empty() {
+        return Some(Whiteout::Invalid);
+    }
+    // The marker sits in the middle of the path, so what it names has to be
+    // put back together rather than sliced out.
+    let mut named = Vec::with_capacity(dir.len() + 1 + target.len());
+    if !dir.is_empty() {
+        named.extend_from_slice(dir);
+        named.push(b'/');
+    }
+    named.extend_from_slice(target);
+    Some(Whiteout::Named(named))
+}
+
+fn split(path: &[u8]) -> (&[u8], &[u8]) {
+    match path.iter().rposition(|&byte| byte == b'/') {
+        Some(at) => (&path[..at], &path[at + 1..]),
+        None => (&path[..0], path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_marker_names_what_it_hides() {
+        assert!(matches!(of(b"dir/.wh..wh..opq"), Some(Whiteout::Opaque(d)) if d == b"dir"));
+        assert!(matches!(of(b"dir/.wh.name"), Some(Whiteout::Named(n)) if n == b"dir/name"));
+        assert!(matches!(of(b".wh.name"), Some(Whiteout::Named(n)) if n == b"name"));
+        assert!(of(b"dir/name").is_none());
+    }
+
+    /// A marker at the top of a layer names the rootfs, which is not a path
+    /// under it and so has no name of its own.
+    #[test]
+    fn a_marker_at_the_top_of_a_layer_names_the_rootfs() {
+        assert!(matches!(of(b".wh..wh..opq"), Some(Whiteout::Opaque(d)) if d.is_empty()));
+    }
+
+    #[test]
+    fn a_marker_naming_nothing_is_invalid_rather_than_ordinary() {
+        assert!(matches!(of(b"dir/.wh."), Some(Whiteout::Invalid)));
+        assert!(matches!(of(b".wh."), Some(Whiteout::Invalid)));
+    }
+
+    #[test]
+    fn the_opaque_marker_is_itself_a_whiteout_name() {
+        assert!(OPAQUE.starts_with(PREFIX));
+    }
+}


### PR DESCRIPTION
The plan and the walk each carried their own copy of the `.wh.` rules: one over bytes with the marker parsed out of the entry path, the other over `&str` with it parsed out of the resolved destination. They agreed by inspection alone, and on one case they did not agree at all.

An opaque marker at the top of a layer names the rootfs itself. The walk empties it. The plan asked its tree for everything under a path of nothing, sought a key of `/`, found none, and kept every entry the walk had removed -- so the span route went on to place them. `remove_under` now reads an empty directory as the rootfs, and leaves the rootfs entry itself alone, because the marker empties the directory rather than deleting it.

`extract::whiteout` now holds the markers, what they name, and the `.wh.` that names nothing, which was a `None` the plan had to recognise by comparing basenames and is now a variant both routes match on.