### PR TITLE
refactor: place entries through one module

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -12,7 +12,7 @@ use crate::fsutil;
 use crate::log::{log, warning};
 
 use super::RootfsExtractor;
-use super::file::{prepare_directory, set_symlink_mtime, unpack_regular};
+use super::file::{create_directory, place_symlink, prepare_directory, unpack_regular};
 use super::pipeline::CHUNK_BYTES;
 use super::whiteout::{self, Whiteout};
 
@@ -168,15 +168,9 @@ impl RootfsExtractor {
                     self.parents.forget(&dst);
                 }
                 self.deferred_modes.push((dst.clone(), mode));
-                match fs::create_dir(&dst) {
-                    Ok(()) => {}
-                    // `prepare_directory` cleared anything that was not a
-                    // directory, so what is left is one to keep.
-                    Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
-                    Err(err) => {
-                        return Err(Error::io(format!("creating {}", dst.display()), err));
-                    }
-                }
+                // `prepare_directory` cleared anything that was not a
+                // directory, so what is left is one to keep.
+                create_directory(&dst)?;
                 continue;
             }
 
@@ -194,12 +188,10 @@ impl RootfsExtractor {
             match entry_type {
                 EntryType::Symlink => {
                     let target = link_name(&entry, layer)?.ok_or_else(unsafe_entry)?;
-                    std::os::unix::fs::symlink(&target, &dst).io_context(|| {
+                    let mtime = entry.header().mtime().ok();
+                    place_symlink(&dst, target.as_os_str().as_bytes(), mtime).io_context(|| {
                         format!("extracting {:?} from layer {layer}", path.display())
                     })?;
-                    if let Ok(mtime) = entry.header().mtime() {
-                        set_symlink_mtime(&dst, mtime);
-                    }
                 }
                 EntryType::Link => {
                     let target = link_name(&entry, layer)?.ok_or_else(unsafe_entry)?;

--- a/source/src/extract/file.rs
+++ b/source/src/extract/file.rs
@@ -1,8 +1,10 @@
 //! Placing a single filesystem object, once its path has been checked.
 //!
-//! These replace the parts of `tar`'s own `unpack_in` the extractor needs.
-//! Every path reaching them has already been resolved and had its parent
-//! created, so none of them re-derives that.
+//! These replace the parts of `tar`'s own `unpack_in` the extractor needs, and
+//! are what both routes place through: the walk hands them entries out of a
+//! tar stream, the span route entries out of a table. Every path reaching them
+//! has already been resolved and had its parent created, so none of them
+//! re-derives that.
 
 use std::fs;
 use std::io::{self, Read, Write};
@@ -13,6 +15,48 @@ use std::path::Path;
 
 use crate::error::{Error, Result};
 use crate::fsutil;
+
+/// What to do about something already standing where an entry goes.
+#[derive(Clone, Copy)]
+pub(super) enum Occupied {
+    /// Replace it. The walk builds the tree a layer at a time, and a later
+    /// layer takes a path from an earlier one.
+    Replace,
+    /// Refuse it. The plan resolved the whole image and says each path is
+    /// placed once, so anything already there means the plan and the tree
+    /// disagree.
+    Refuse,
+}
+
+/// Creates a file with the mode its entry asked for, reporting whether
+/// something had to be removed to make room for it.
+///
+/// Creating with the final mode avoids a window in which the file is more
+/// permissive than the layer asked for. Permissions are checked when the file
+/// is opened, so a read-only mode does not stop the writes that follow.
+///
+/// The first attempt is exclusive, which costs nothing when the path is free,
+/// as it is for every file in the first and largest layer. It also refuses to
+/// follow a symlink already sitting there, so the path only has to be cleared
+/// on the rare occasion a later layer replaces something, rather than being
+/// stat'd and unlinked for every file in the image.
+pub(super) fn create_file(
+    dst: &Path,
+    mode: u32,
+    occupied: Occupied,
+) -> io::Result<(fs::File, bool)> {
+    match open_exclusive(dst, mode) {
+        Ok(file) => Ok((file, false)),
+        Err(err)
+            if err.kind() == io::ErrorKind::AlreadyExists
+                && matches!(occupied, Occupied::Replace) =>
+        {
+            fsutil::remove_any(dst).map_err(io::Error::other)?;
+            Ok((open_exclusive(dst, mode)?, true))
+        }
+        Err(err) => Err(err),
+    }
+}
 
 /// Writes a regular file, replacing `tar`'s own unpacking so that the copy can
 /// use a buffer sized for the pipeline rather than std's default. This only
@@ -26,25 +70,7 @@ pub(super) fn unpack_regular<R: Read>(
     mode: u32,
     buffer: &mut [u8],
 ) -> io::Result<bool> {
-    // Creating with the final mode avoids a window in which the file is more
-    // permissive than the layer asked for. Permissions are checked when the
-    // file is opened, so a read-only mode does not stop the writes below.
-    //
-    // The first attempt is exclusive, which costs nothing when the path is
-    // free, as it is for every file in the first and largest layer. It also
-    // refuses to follow a symlink already sitting there, so the path only has
-    // to be cleared on the rare occasion a later layer replaces something,
-    // rather than being stat'd and unlinked for every file in the image.
-    let mut replaced = false;
-    let mut file = match open_exclusive(dst, mode) {
-        Ok(file) => file,
-        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-            fsutil::remove_any(dst).map_err(io::Error::other)?;
-            replaced = true;
-            open_exclusive(dst, mode)?
-        }
-        Err(err) => return Err(err),
-    };
+    let (mut file, replaced) = create_file(dst, mode, Occupied::Replace)?;
 
     let mut filled = 0;
     loop {
@@ -107,7 +133,7 @@ fn set_mtime(file: &fs::File, mtime: u64) {
 
 /// The same for a symlink, which has no descriptor to hang the call on and
 /// must not be followed to the file it names.
-pub(super) fn set_symlink_mtime(path: &Path, mtime: u64) {
+fn set_symlink_mtime(path: &Path, mtime: u64) {
     let Ok(path) = std::ffi::CString::new(path.as_os_str().as_bytes()) else {
         return;
     };
@@ -126,6 +152,28 @@ pub(super) fn set_symlink_mtime(path: &Path, mtime: u64) {
             libc::AT_SYMLINK_NOFOLLOW,
         )
     };
+}
+
+/// Links `dst` to wherever the entry pointed, and gives it the timestamp the
+/// entry carried. A symlink target is followed from where the link stands, so
+/// it is written exactly as the layer spelled it.
+pub(super) fn place_symlink(dst: &Path, target: &[u8], mtime: Option<u64>) -> io::Result<()> {
+    std::os::unix::fs::symlink(Path::new(std::ffi::OsStr::from_bytes(target)), dst)?;
+    if let Some(mtime) = mtime {
+        set_symlink_mtime(dst, mtime);
+    }
+    Ok(())
+}
+
+/// Creates a directory, treating one that is already there as done: the walk
+/// meets a directory every layer names, and the plan creates the tree before
+/// any layer runs.
+pub(super) fn create_directory(dst: &Path) -> Result<()> {
+    match fs::create_dir(dst) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        Err(err) => Err(Error::io(format!("creating {}", dst.display()), err)),
+    }
 }
 
 /// Keeps existing directories (including symlinks to directories) intact so

--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -116,13 +116,7 @@ impl RootfsExtractor {
         let mut path = PathBuf::new();
         for (relative, mode) in self.plan.directories() {
             fsutil::join_under(root.as_std_path(), relative, &mut path);
-            match fs::create_dir(&path) {
-                Ok(()) => {}
-                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
-                Err(err) => {
-                    return Err(Error::io(format!("creating {}", path.display()), err));
-                }
-            }
+            file::create_directory(&path)?;
             self.deferred_modes.push((path.clone(), *mode));
         }
         log!("Created {} directories", self.plan.directories().len());

--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -20,8 +20,6 @@
 
 use std::fs;
 use std::io::Write;
-use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -37,7 +35,7 @@ use crate::log::log;
 use crate::sys::Mapping;
 use crate::zinfo;
 
-use super::file::{finish_file, set_symlink_mtime};
+use super::file::{Occupied, create_file, finish_file, place_symlink};
 use super::plan::{Plan, Work};
 
 /// Everything one layer contributes, held open for the length of the run.
@@ -105,7 +103,7 @@ pub fn extract(
     // have refused the image, but a link under another link needs it standing.
     for &(layer, entry) in &work.symlinks {
         let entry = &plan.table(layer as usize).entries[entry as usize];
-        place_symlink(root, entry)?;
+        place_link(root, entry)?;
     }
 
     let units = plan_units(&layers, work, plan);
@@ -345,26 +343,18 @@ fn run_span(
 fn write_file(root: &Path, path: &mut PathBuf, entry: &Entry, body: &[u8]) -> Result<()> {
     resolve(root, path, entry);
     let context = || format!("extracting {:?}", String::from_utf8_lossy(&entry.path));
-    // Exclusive, so this neither follows a symlink standing here nor writes
-    // over something the plan did not account for.
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(entry.mode)
-        .open(&path)
-        .io_context(context)?;
+    // The plan says this path is placed once, so anything already standing
+    // here means the plan and the tree have parted company.
+    let (mut file, _) = create_file(path, entry.mode, Occupied::Refuse).io_context(context)?;
     file.write_all(body).io_context(context)?;
     finish_file(&file, entry.mode, Some(entry.mtime)).io_context(context)
 }
 
-fn place_symlink(root: &Path, entry: &Entry) -> Result<()> {
+fn place_link(root: &Path, entry: &Entry) -> Result<()> {
     let mut path = PathBuf::new();
     resolve(root, &mut path, entry);
-    let target = Path::new(std::ffi::OsStr::from_bytes(&entry.link));
-    std::os::unix::fs::symlink(target, &path)
-        .io_context(|| format!("linking {:?}", String::from_utf8_lossy(&entry.path)))?;
-    set_symlink_mtime(&path, entry.mtime);
-    Ok(())
+    place_symlink(&path, &entry.link, Some(entry.mtime))
+        .io_context(|| format!("linking {:?}", String::from_utf8_lossy(&entry.path)))
 }
 
 fn place_hard_link(root: &Path, entry: &Entry) -> Result<()> {


### PR DESCRIPTION
Both routes create a file with the mode its entry asked for, both write the mode again afterwards because the umask applies to creation and not to `fchmod`, both link a symlink and then set its timestamp without following it, and both create directories that may already be there. Each had written that out for itself, so the two could drift apart in exactly the places the route agreement fixtures are there to catch.

`extract::file` now holds all of it. What the routes genuinely disagree about is what to do with an occupied path, and that is now the argument they pass rather than the reason they each keep a copy: the walk builds the tree a layer at a time and replaces, the span route was promised each path once and refuses.