### PR TITLE
refactor: check a blob and open a blob in one place each

### DIFF
--- a/source/src/extract/pipeline.rs
+++ b/source/src/extract/pipeline.rs
@@ -14,7 +14,8 @@ use std::thread;
 use sha2::{Digest, Sha256};
 
 use crate::error::{Error, Result};
-use crate::image::{Descriptor, hex_encode, parse_digest};
+use crate::image::{Descriptor, verify_digest};
+use crate::sys::Blob;
 use crate::zinfo;
 
 /// Size of each buffer handed from the decompressor to the writer.
@@ -147,21 +148,7 @@ pub(super) fn inflate_blob(
     // decoder, and with it the receiving end, has to go before this joins.
     drop(decoder);
     let state = hashing.join().unwrap_or_default();
-    if descriptor.size != 0 && descriptor.size != state.bytes {
-        return Err(Error::SizeMismatch {
-            digest: descriptor.digest.clone(),
-            expected: descriptor.size,
-            actual: state.bytes,
-        });
-    }
-    let actual = hex_encode(&state.hasher.finalize());
-    if actual != parse_digest(&descriptor.digest)?.hex {
-        return Err(Error::DigestMismatch {
-            digest: descriptor.digest.clone(),
-            actual,
-        });
-    }
-    Ok(())
+    verify_digest(descriptor, state.bytes, &state.hasher.finalize())
 }
 
 /// Runs on the decompression thread when the layer has a checkpoint index:
@@ -170,29 +157,22 @@ pub(super) fn inflate_blob(
 /// blob is mapped; hashing it for the digest check then happens over the same
 /// pages on a thread of its own, instead of alongside a read.
 pub(super) fn inflate_indexed(
-    mut file: fs::File,
+    file: fs::File,
     index: &zinfo::Index,
     descriptor: &Descriptor,
     sender: SyncSender<io::Result<Chunk>>,
 ) -> Result<()> {
-    let len = file.metadata().map_or(0, |m| m.len()) as usize;
-    let mapped = crate::sys::Mapping::of(&file, len);
-    // Nothing to map, or the kernel would not: the spans still need the whole
-    // blob, so fall back to a copy of it.
-    let mut read = Vec::new();
-    if mapped.is_none()
-        && let Err(err) = file.read_to_end(&mut read)
-    {
-        let _ = sender.send(Err(io::Error::other(err.to_string())));
-        return Err(Error::io(
-            format!("reading layer {}", descriptor.digest),
-            err,
-        ));
-    }
-    let blob: &[u8] = match &mapped {
-        Some(mapping) => mapping,
-        None => &read,
+    let blob = match Blob::of(&file) {
+        Ok(blob) => blob,
+        Err(err) => {
+            let _ = sender.send(Err(io::Error::other(err.to_string())));
+            return Err(Error::io(
+                format!("reading layer {}", descriptor.digest),
+                err,
+            ));
+        }
     };
+    let blob: &[u8] = &blob;
 
     let spans = index.checkpoints.len();
     let workers = thread::available_parallelism()
@@ -259,20 +239,7 @@ pub(super) fn inflate_indexed(
 
     // The digest verdict comes first: a blob that fails it explains any span
     // error, since the index describes the blob the descriptor names.
-    if descriptor.size != 0 && descriptor.size != blob.len() as u64 {
-        return Err(Error::SizeMismatch {
-            digest: descriptor.digest.clone(),
-            expected: descriptor.size,
-            actual: blob.len() as u64,
-        });
-    }
-    let actual = hex_encode(&digest);
-    if actual != parse_digest(&descriptor.digest)?.hex {
-        return Err(Error::DigestMismatch {
-            digest: descriptor.digest.clone(),
-            actual,
-        });
-    }
+    verify_digest(descriptor, blob.len() as u64, &digest)?;
     match span_error {
         Some(err) => Err(err),
         None => Ok(()),

--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -26,13 +26,12 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread;
 
 use camino::Utf8Path;
-use sha2::{Digest, Sha256};
 
 use crate::entries::{Entry, Table};
 use crate::error::{Error, IoContext, Result};
-use crate::image::{Descriptor, Layout, hex_encode, parse_digest};
+use crate::image::{Descriptor, Layout};
 use crate::log::log;
-use crate::sys::Mapping;
+use crate::sys::Blob;
 use crate::zinfo;
 
 use super::file::{Occupied, create_file, finish_file, place_symlink};
@@ -41,7 +40,7 @@ use super::plan::{Plan, Work};
 /// Everything one layer contributes, held open for the length of the run.
 struct Layer {
     descriptor: Descriptor,
-    blob: Mapping,
+    blob: Blob,
     index: zinfo::Index,
 }
 
@@ -136,17 +135,9 @@ fn open_layers(
         .iter()
         .zip(indexes)
         .map(|(descriptor, index)| {
-            let file = layout.open_blob(descriptor)?;
-            let len = file.metadata().map_or(0, |m| m.len()) as usize;
-            let blob = Mapping::of(&file, len).ok_or_else(|| {
-                Error::io(
-                    format!("mapping layer {}", descriptor.digest),
-                    std::io::Error::other("the blob could not be mapped"),
-                )
-            })?;
             Ok(Layer {
                 descriptor: descriptor.clone(),
-                blob,
+                blob: layout.map_blob(descriptor)?,
                 index,
             })
         })
@@ -376,20 +367,5 @@ fn resolve(root: &Path, path: &mut PathBuf, entry: &Entry) {
 }
 
 fn verify(layer: &Layer) -> Result<()> {
-    let descriptor = &layer.descriptor;
-    if descriptor.size != 0 && descriptor.size != layer.blob.len() as u64 {
-        return Err(Error::SizeMismatch {
-            digest: descriptor.digest.clone(),
-            expected: descriptor.size,
-            actual: layer.blob.len() as u64,
-        });
-    }
-    let actual = hex_encode(&Sha256::digest(&*layer.blob));
-    if actual != parse_digest(&descriptor.digest)?.hex {
-        return Err(Error::DigestMismatch {
-            digest: descriptor.digest.clone(),
-            actual,
-        });
-    }
-    Ok(())
+    crate::image::verify(&layer.descriptor, &layer.blob)
 }

--- a/source/src/image.rs
+++ b/source/src/image.rs
@@ -208,6 +208,13 @@ impl Layout {
         File::open(&path).io_context(|| format!("opening blob {path}"))
     }
 
+    /// Opens a blob as bytes, for a caller that needs random access over the
+    /// whole of it. The digest is still the caller's to check.
+    pub fn map_blob(&self, descriptor: &Descriptor) -> Result<crate::sys::Blob> {
+        let file = self.open_blob(descriptor)?;
+        crate::sys::Blob::of(&file).io_context(|| format!("reading blob {}", descriptor.digest))
+    }
+
     /// Reads a small (metadata) blob and verifies its size and digest.
     pub fn read_metadata_blob(&self, descriptor: &Descriptor) -> Result<Vec<u8>> {
         let path = self.blob_path(&descriptor.digest)?;
@@ -346,15 +353,22 @@ impl Layout {
 
 /// Checks in-memory bytes against the size and digest recorded in a descriptor.
 pub fn verify(descriptor: &Descriptor, bytes: &[u8]) -> Result<()> {
-    if descriptor.size != 0 && descriptor.size != bytes.len() as u64 {
+    verify_digest(descriptor, bytes.len() as u64, &Sha256::digest(bytes))
+}
+
+/// The same check for a caller that has hashed the bytes already, which is how
+/// the pipeline hashes a blob alongside the work it accompanies rather than in
+/// a pass of its own.
+pub fn verify_digest(descriptor: &Descriptor, size: u64, digest: &[u8]) -> Result<()> {
+    if descriptor.size != 0 && descriptor.size != size {
         return Err(Error::SizeMismatch {
             digest: descriptor.digest.clone(),
             expected: descriptor.size,
-            actual: bytes.len() as u64,
+            actual: size,
         });
     }
     let parsed = parse_digest(&descriptor.digest)?;
-    let actual = hex_encode(&Sha256::digest(bytes));
+    let actual = hex_encode(digest);
     if actual != parsed.hex {
         return Err(Error::DigestMismatch {
             digest: descriptor.digest.clone(),

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -155,17 +155,9 @@ fn index(args: IndexArgs) -> Result<i32> {
 fn index_blob(blob: &Utf8Path, checkpoints: &Utf8Path, entries: &Utf8Path, span: u64) -> Result<()> {
     let file =
         std::fs::File::open(blob).map_err(|source| Error::io(format!("opening {blob}"), source))?;
-    let len = file.metadata().map_or(0, |m| m.len()) as usize;
-    let mapped = sys::Mapping::of(&file, len);
-    let mut read = Vec::new();
-    if mapped.is_none() {
-        std::io::Read::read_to_end(&mut &file, &mut read)
-            .map_err(|source| Error::io(format!("reading {blob}"), source))?;
-    }
-    let bytes: &[u8] = match &mapped {
-        Some(mapping) => mapping,
-        None => &read,
-    };
+    let bytes =
+        sys::Blob::of(&file).map_err(|source| Error::io(format!("reading {blob}"), source))?;
+    let bytes: &[u8] = &bytes;
     // Which blob failed matters more than usual here: this runs as a build
     // action over every layer of an image at once.
     let named = |source| match source {

--- a/source/src/sys.rs
+++ b/source/src/sys.rs
@@ -86,6 +86,43 @@ impl Drop for Mapping {
     }
 }
 
+/// A whole file as bytes, mapped where the kernel allows it and read into
+/// memory where it does not.
+///
+/// Random access over a blob is what the span route and the index builder both
+/// need, and neither can do anything with a mapping that was refused, so the
+/// fallback belongs with the mapping rather than at each of them.
+pub struct Blob {
+    mapped: Option<Mapping>,
+    read: Vec<u8>,
+}
+
+impl Blob {
+    pub fn of(mut file: &File) -> std::io::Result<Self> {
+        let len = file.metadata().map_or(0, |metadata| metadata.len()) as usize;
+        if let Some(mapped) = Mapping::of(file, len) {
+            return Ok(Blob {
+                mapped: Some(mapped),
+                read: Vec::new(),
+            });
+        }
+        let mut read = Vec::with_capacity(len);
+        file.read_to_end(&mut read)?;
+        Ok(Blob { mapped: None, read })
+    }
+}
+
+impl std::ops::Deref for Blob {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        match &self.mapped {
+            Some(mapped) => mapped,
+            None => &self.read,
+        }
+    }
+}
+
 pub fn euid() -> u32 {
     // SAFETY: geteuid is always successful and has no preconditions.
     unsafe { libc::geteuid() }


### PR DESCRIPTION
Three copies of the same size and digest check had grown: the streaming pipeline hashed as it read, the indexed pipeline hashed the mapping on a thread of its own, and the span route hashed it again as a unit of work. All three then spelled out the same two comparisons and the same two errors, next to `image::verify`, which already was that check.

`image::verify_digest` is now the one the callers that hash for themselves use, `image::verify` is it with the hashing included, and the span route simply calls the latter.

The mapping dance was also written out three times -- map the whole blob, fall back to reading it when the kernel will not -- except in the span route, which had no fallback at all and failed the extraction outright. `sys::Blob` holds it once, `Layout::map_blob` opens one, and the span route gets the fallback it was missing.