### PR TITLE
refactor: name and read the layer sidecars in one place

### DIFF
--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -226,10 +226,6 @@ impl RootfsExtractor {
 }
 
 /// Reads the checkpoint index recorded for a layer, if there is a usable one.
-///
-/// An index is an optimisation, so anything wrong with it means falling back
-/// rather than failing: whichever path ends up reading the layer decides what
-/// it actually contains.
 fn index_at(dir: &Utf8Path, descriptor: &Descriptor) -> Option<zinfo::Index> {
     if compression_of(&descriptor.media_type) != Some(Compression::Gzip) {
         return None;
@@ -238,20 +234,6 @@ fn index_at(dir: &Utf8Path, descriptor: &Descriptor) -> Option<zinfo::Index> {
         return None;
     }
     let hex = parse_digest(&descriptor.digest).ok()?.hex;
-    let path = dir.join(format!("{hex}.zinfo"));
-    let file = match fs::File::open(&path) {
-        Ok(file) => file,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return None,
-        Err(err) => {
-            warning!("ignoring layer index {path}: {err}");
-            return None;
-        }
-    };
-    match zinfo::Index::read_from(io::BufReader::new(file)) {
-        Ok(index) => Some(index),
-        Err(err) => {
-            warning!("ignoring layer index {path}: {err}");
-            None
-        }
-    }
+    let path = crate::sidecar::checkpoints_at(dir, &hex);
+    crate::sidecar::read(&path, zinfo::Index::read_from)
 }

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -24,7 +24,7 @@ use camino::Utf8Path;
 use crate::entries::{Kind, Table};
 use crate::fsutil;
 use crate::image::{Descriptor, parse_digest};
-use crate::log::{log, warning};
+use crate::log::log;
 
 use super::whiteout::{self, Whiteout};
 
@@ -80,21 +80,10 @@ impl Plan {
             let Ok(digest) = parse_digest(&layer.digest) else {
                 return Plan::default();
             };
-            let path = dir.join(format!("{}.entries", digest.hex));
-            let file = match std::fs::File::open(&path) {
-                Ok(file) => file,
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Plan::default(),
-                Err(err) => {
-                    warning!("ignoring entry table {path}: {err}");
-                    return Plan::default();
-                }
-            };
-            match Table::read_from(std::io::BufReader::new(file)) {
-                Ok(table) => tables.push(table),
-                Err(err) => {
-                    warning!("ignoring entry table {path}: {err}");
-                    return Plan::default();
-                }
+            let path = crate::sidecar::entries_at(dir, &digest.hex);
+            match crate::sidecar::read(&path, Table::read_from) {
+                Some(table) => tables.push(table),
+                None => return Plan::default(),
             }
         }
         Plan::resolve(layers, tables)

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -8,6 +8,7 @@ mod image;
 mod launcher;
 mod log;
 mod runtime;
+mod sidecar;
 mod spec;
 mod sys;
 mod zinfo;
@@ -218,8 +219,8 @@ fn index_layout(layout: &Utf8Path, output: &Utf8Path, span: u64) -> Result<()> {
             let blob = layout.blob_path(&layer.digest)?;
             work.push((
                 blob,
-                output.join(format!("{hex}.zinfo")),
-                output.join(format!("{hex}.entries")),
+                sidecar::checkpoints_at(output, &hex),
+                sidecar::entries_at(output, &hex),
             ));
         }
     }

--- a/source/src/sidecar.rs
+++ b/source/src/sidecar.rs
@@ -1,0 +1,50 @@
+//! The files recorded beside a layer at build time: a checkpoint index and an
+//! entry table, named after the layer's digest.
+//!
+//! Both are optimisations. Whoever ends up reading the layer decides what it
+//! actually contains, so a sidecar that is missing, unreadable or not what it
+//! claims means falling back to reading the layer rather than failing.
+//!
+//! The names live here because `oci_runtime index` writes them and extraction
+//! reads them, and a convention spelled out in both places is one that can
+//! quietly stop matching: nothing fails, the sidecars are simply never found.
+
+use std::fs::File;
+use std::io::{self, BufReader};
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::log::warning;
+
+/// Where a layer's checkpoint index goes.
+pub fn checkpoints_at(dir: &Utf8Path, hex: &str) -> Utf8PathBuf {
+    dir.join(format!("{hex}.zinfo"))
+}
+
+/// Where a layer's entry table goes.
+pub fn entries_at(dir: &Utf8Path, hex: &str) -> Utf8PathBuf {
+    dir.join(format!("{hex}.entries"))
+}
+
+/// Reads a sidecar, or `None` when there is not a usable one.
+///
+/// One that is not there is ordinary: an image may simply not have been
+/// indexed. One that is there and will not read is worth saying out loud,
+/// since something built it and it is not being used.
+pub fn read<T>(path: &Utf8Path, parse: impl FnOnce(BufReader<File>) -> io::Result<T>) -> Option<T> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            warning!("ignoring {path}: {err}");
+            return None;
+        }
+    };
+    match parse(BufReader::new(file)) {
+        Ok(parsed) => Some(parsed),
+        Err(err) => {
+            warning!("ignoring {path}: {err}");
+            None
+        }
+    }
+}


### PR DESCRIPTION
`<hex>.zinfo` and `<hex>.entries` were spelled in three places: the index command that writes them, the extractor that reads the checkpoints, and the plan that reads the tables. A convention held in three places is one that can quietly stop matching, and nothing would fail if it did -- the sidecars would simply never be found and every run would take the slow route.

Both readers also had their own copy of the same open, warn and fall back: a sidecar that is missing is ordinary, one that will not read is worth saying out loud, and neither is an error, because whoever reads the layer decides what it holds.

`sidecar` now holds the names and the reading.