### PR TITLE
fix: link the copy a hard link was made against

### DIFF
--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -239,7 +239,9 @@ fn canonicalise(tables: &mut [Table]) -> bool {
 ///   the tree as it is built;
 /// - a hard link naming something the final tree does not hold, or holds
 ///   behind a symlink, where linking would follow the symlink to wherever it
-///   points and the walk checks that against the rootfs as it goes.
+///   points and the walk checks that against the rootfs as it goes;
+/// - a hard link whose target is replaced after it, where the copy the walk
+///   linked is not the copy that survives.
 fn placeable(tree: &BTreeMap<&[u8], Node>, tables: &[Table]) -> Option<Work> {
     let mut work = Work {
         files: vec![Vec::new(); tables.len()],
@@ -262,7 +264,16 @@ fn placeable(tree: &BTreeMap<&[u8], Node>, tables: &[Table]) -> Option<Work> {
             Kind::Symlink => work.symlinks.push((layer as u32, entry as u32)),
             Kind::HardLink => {
                 let target = tables[layer].entries[entry].link.as_slice();
-                if !tree.contains_key(target) || behind_a_link(tree, target) {
+                let at = tree.get(target)?;
+                if behind_a_link(tree, target) {
+                    return None;
+                }
+                // The walk links the copy standing at the target when the
+                // entry appears, and a later layer replacing that path
+                // unlinks it rather than writing through it. Links are placed
+                // here only once every file is on disk, so the copy that
+                // survives is the only one there is to link.
+                if at.owner > (layer, entry) {
                     return None;
                 }
                 work.hard_links.push((layer as u32, entry as u32))
@@ -691,11 +702,49 @@ mod tests {
             assert!(plan.work().is_none());
         }
 
+        /// The walk links the copy standing at the target when the entry
+        /// appears, and a later layer replacing that path unlinks it rather
+        /// than writing through it. Links are placed after every file, by
+        /// which time only the surviving copy is there to link.
+        #[test]
+        fn a_hard_link_whose_target_a_later_layer_replaces() {
+            let mut link = of_kind("link", Kind::HardLink);
+            link.link = b"target".to_vec();
+            let (plan, _) = plan_of(vec![
+                layer(vec![file("target"), link]),
+                layer(vec![file("target")]),
+            ]);
+            assert!(plan.work().is_none());
+        }
+
+        /// The same layer, later in it: the walk has already replaced the
+        /// copy by the time it links, so this is the same case.
+        #[test]
+        fn a_hard_link_whose_target_its_own_layer_replaces_afterwards() {
+            let mut link = of_kind("link", Kind::HardLink);
+            link.link = b"target".to_vec();
+            let (plan, _) = plan_of(vec![layer(vec![file("target"), link, file("target")])]);
+            assert!(plan.work().is_none());
+        }
+
         #[test]
         fn the_rootfs_named_as_anything_but_a_directory() {
             let (plan, _) = plan_of(vec![layer(vec![file(".")])]);
             assert!(!plan.is_resolved());
         }
+    }
+
+    /// A target replaced before the link is the copy the walk links, so there
+    /// is nothing for the span route to get wrong.
+    #[test]
+    fn a_hard_link_made_against_the_surviving_copy_is_placeable() {
+        let mut link = of_kind("link", Kind::HardLink);
+        link.link = b"target".to_vec();
+        let (plan, _) = plan_of(vec![
+            layer(vec![file("target")]),
+            layer(vec![file("target"), link]),
+        ]);
+        assert!(plan.work().is_some());
     }
 
     /// `tar -C dir .` writes the rootfs itself into every layer, so planning

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -1260,6 +1260,36 @@ fn every_route_agrees_on_hard_links() {
     );
 }
 
+/// A hard link is made against the copy standing when the entry appears. A
+/// later layer replacing that path unlinks it and writes a new file, so the
+/// link keeps the contents it was made against and stops sharing an inode.
+///
+/// The span route places links once every file is on disk, by which time only
+/// the surviving copy is there to link, so it declines the image instead.
+#[test]
+fn a_hard_link_keeps_the_copy_it_was_made_against() {
+    let layers = [
+        tar_of(|b| {
+            append_file(b, "target", b"first");
+            append_hard_link(b, "link", "target");
+        }),
+        tar_of(|b| append_file(b, "target", b"second")),
+    ];
+    let routes = [Route::Streaming, Route::Planned];
+    for_each_route("hard-link-replaced", &routes, &layers, |route, rootfs| {
+        assert_eq!(
+            fs::read_to_string(rootfs.join("link")).expect("link"),
+            "first",
+            "{route:?} linked the wrong copy"
+        );
+        assert_eq!(
+            fs::read_to_string(rootfs.join("target")).expect("target"),
+            "second",
+            "{route:?} kept the wrong copy"
+        );
+    });
+}
+
 #[test]
 fn every_route_agrees_when_a_directory_becomes_a_symlink() {
     assert_routes_agree(


### PR DESCRIPTION
A hard link names what is on disk when its entry appears. When a later layer replaces that path the walk unlinks the old file and writes a new one, so the link keeps the contents it was made against and stops sharing an inode with the path it named.

The span route places links after every file, by which time only the surviving copy is there, so it linked the wrong contents. The fixture is two layers: `target` = "first" with `link` beside it, then `target` = "second". The walk gives `link` = "first"; the span route gave "second".

Placing this correctly means writing a copy the plan exists to skip and then replacing it, so the plan declines the image instead and the walk takes it, which is what every other case only the walk can judge already does. Real images have single figures of hard links and this needs one of them to be replaced afterwards.

browserless/chromium is unaffected -- it still plans, and still extracts as
299 units on 8 workers. Interleaved on disk, min of five: wall 2.285 ->
2.338 s, cpu 11.365 -> 11.556 s, 46,510 entries either way.