### PR TITLE
refactor: classify a tar entry in one place

### DIFF
--- a/source/src/entries.rs
+++ b/source/src/entries.rs
@@ -40,6 +40,32 @@ pub enum Kind {
 }
 
 impl Kind {
+    /// What the extractor will do with the entry a header describes.
+    ///
+    /// Classified by that rather than by the type alone: a continuous file is
+    /// a plain file, while a sparse one ends up as a file but is not stored as
+    /// one. The walk and the table have to agree here, or the plan reasons
+    /// about an entry the walk then treats as something else.
+    pub fn of(header: &tar::Header) -> Self {
+        let entry_type = header.entry_type();
+        if entry_type.is_dir() {
+            Kind::Directory
+        } else if entry_type.is_symlink() {
+            Kind::Symlink
+        } else if entry_type.is_hard_link() {
+            Kind::HardLink
+        } else if entry_type == tar::EntryType::GNUSparse {
+            Kind::Sparse
+        } else if matches!(
+            entry_type,
+            tar::EntryType::Regular | tar::EntryType::Continuous
+        ) {
+            Kind::File
+        } else {
+            Kind::Unsupported
+        }
+    }
+
     fn code(self) -> u8 {
         match self {
             Kind::File => 0,
@@ -102,33 +128,13 @@ impl Table {
             let mut entry = entry.io_context(|| context.to_string())?;
             let xattrs = xattr_names(&mut entry).io_context(|| context.to_string())?;
             let header = entry.header();
-            let entry_type = header.entry_type();
-            // Classified by what the extractor does with it, not by the type
-            // alone: a continuous file is a plain file, while a sparse one
-            // ends up as a file but is not stored as one.
-            let kind = if entry_type.is_dir() {
-                Kind::Directory
-            } else if entry_type.is_symlink() {
-                Kind::Symlink
-            } else if entry_type.is_hard_link() {
-                Kind::HardLink
-            } else if entry_type == tar::EntryType::GNUSparse {
-                Kind::Sparse
-            } else if matches!(
-                entry_type,
-                tar::EntryType::Regular | tar::EntryType::Continuous
-            ) {
-                Kind::File
-            } else {
-                Kind::Unsupported
-            };
             if entries.len() as u32 == MAX_ENTRIES {
                 return Err(Error::io(context, io::Error::other("too many entries")));
             }
             entries.push(Entry {
-                kind,
-                mode: header.mode().unwrap_or(0o755) & 0o7777,
-                mtime: header.mtime().unwrap_or(0),
+                kind: Kind::of(header),
+                mode: mode_of(header),
+                mtime: mtime_of(header),
                 offset: entry.raw_file_position(),
                 size: entry.size(),
                 path: without_trailing_slash(entry.path_bytes().into_owned()),
@@ -233,6 +239,18 @@ fn write_bytes(out: &mut Vec<u8>, bytes: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
+/// The mode an entry asks for, without the bits above the permission bits and
+/// with what `create_dir` would have used when the header does not say.
+pub fn mode_of(header: &tar::Header) -> u32 {
+    header.mode().unwrap_or(0o755) & 0o7777
+}
+
+/// The timestamp an entry asks for. A header that will not give one leaves the
+/// epoch, which is at least the same answer whichever route reads it.
+pub fn mtime_of(header: &tar::Header) -> u64 {
+    header.mtime().unwrap_or(0)
+}
+
 /// The names of the entry's extended attributes, NUL separated.
 ///
 /// Only the names: the values can be large, nothing restores them, and the
@@ -322,6 +340,35 @@ fn read_u64(reader: &mut impl Read) -> io::Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The walk places entries and the table records them, and both ask this.
+    /// A type either route classified for itself is one they could answer
+    /// differently.
+    #[test]
+    fn entries_are_classified_by_what_the_extractor_does_with_them() {
+        let kind_of = |entry_type| {
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(entry_type);
+            Kind::of(&header)
+        };
+        assert_eq!(kind_of(tar::EntryType::Regular), Kind::File);
+        assert_eq!(kind_of(tar::EntryType::Continuous), Kind::File);
+        assert_eq!(kind_of(tar::EntryType::Directory), Kind::Directory);
+        assert_eq!(kind_of(tar::EntryType::Symlink), Kind::Symlink);
+        assert_eq!(kind_of(tar::EntryType::Link), Kind::HardLink);
+        assert_eq!(kind_of(tar::EntryType::GNUSparse), Kind::Sparse);
+        // Device nodes and fifos need privileges the extractor does not have.
+        assert_eq!(kind_of(tar::EntryType::Char), Kind::Unsupported);
+        assert_eq!(kind_of(tar::EntryType::Block), Kind::Unsupported);
+        assert_eq!(kind_of(tar::EntryType::Fifo), Kind::Unsupported);
+    }
+
+    #[test]
+    fn a_mode_is_taken_without_the_bits_above_the_permission_bits() {
+        let mut header = tar::Header::new_gnu();
+        header.set_mode(0o104755);
+        assert_eq!(mode_of(&header), 0o4755);
+    }
 
     fn sample() -> Vec<u8> {
         let mut builder = tar::Builder::new(Vec::new());

--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -5,8 +5,7 @@ use std::io::{self, Read};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
-use tar::EntryType;
-
+use crate::entries::{Kind, mode_of, mtime_of};
 use crate::error::{Error, IoContext, Result};
 use crate::fsutil;
 use crate::log::{log, warning};
@@ -58,14 +57,14 @@ impl RootfsExtractor {
             // carries is deferred like any other directory's, and a layer
             // naming the root as anything but a directory is refused.
             if fsutil::names_the_root(path.as_os_str().as_bytes()) {
-                if !entry.header().entry_type().is_dir() {
+                if Kind::of(entry.header()) != Kind::Directory {
                     return Err(Error::UnsafeEntry {
                         layer: layer.to_string(),
                         path: path.display().to_string(),
                     });
                 }
-                let mode = entry.header().mode().unwrap_or(0o755) & 0o7777;
-                self.deferred_modes.push((root.to_path_buf(), mode));
+                self.deferred_modes
+                    .push((root.to_path_buf(), mode_of(entry.header())));
                 continue;
             }
 
@@ -111,12 +110,12 @@ impl RootfsExtractor {
                 None => {}
             }
 
-            let entry_type = entry.header().entry_type();
-            if !is_supported(entry_type) {
+            let kind = Kind::of(entry.header());
+            if kind == Kind::Unsupported {
                 warning!(
                     "skipping unsupported entry {:?} of type {:?} in layer {layer}",
                     path.display(),
-                    entry_type
+                    entry.header().entry_type()
                 );
                 continue;
             }
@@ -128,16 +127,14 @@ impl RootfsExtractor {
 
             // A body a later layer replaces is written and then thrown away,
             // so the plan takes it out before any of that happens.
-            if matches!(entry_type, EntryType::Regular | EntryType::Continuous)
-                && self.plan.is_shadowed(layer, &relative)
-            {
+            if kind.is_file() && self.plan.is_shadowed(layer, &relative) {
                 continue;
             }
 
             // A resolved image had its directory tree built before any layer
             // ran, and a directory entry can only ask for one that is already
             // there.
-            if entry_type.is_dir() && self.plan.is_resolved() {
+            if kind == Kind::Directory && self.plan.is_resolved() {
                 continue;
             }
 
@@ -148,13 +145,13 @@ impl RootfsExtractor {
                 });
             }
 
-            let mode = entry.header().mode().unwrap_or(0o755) & 0o7777;
+            let mode = mode_of(entry.header());
 
             // Regular files are the bulk of a layer, and tar copies them
             // through a buffer of std's default size, which is one write
-            // syscall per 8 KiB. Ours is 32 times larger.
-            if matches!(entry_type, EntryType::Regular | EntryType::Continuous) {
-                entry.set_preserve_mtime(true);
+            // syscall per 8 KiB. Ours is 32 times larger. A sparse body is not
+            // a flat run of the stream, so `tar` still places those.
+            if kind == Kind::File {
                 let replaced = unpack_regular(&mut entry, &dst, mode, &mut buffer)
                     .io_context(|| format!("extracting {:?} from layer {layer}", path.display()))?;
                 if replaced {
@@ -163,7 +160,7 @@ impl RootfsExtractor {
                 continue;
             }
 
-            if entry_type.is_dir() {
+            if kind == Kind::Directory {
                 if prepare_directory(&dst)? {
                     self.parents.forget(&dst);
                 }
@@ -185,15 +182,15 @@ impl RootfsExtractor {
                 path: path.display().to_string(),
             };
 
-            match entry_type {
-                EntryType::Symlink => {
+            match kind {
+                Kind::Symlink => {
                     let target = link_name(&entry, layer)?.ok_or_else(unsafe_entry)?;
-                    let mtime = entry.header().mtime().ok();
+                    let mtime = mtime_of(entry.header());
                     place_symlink(&dst, target.as_os_str().as_bytes(), mtime).io_context(|| {
                         format!("extracting {:?} from layer {layer}", path.display())
                     })?;
                 }
-                EntryType::Link => {
+                Kind::HardLink => {
                     let target = link_name(&entry, layer)?.ok_or_else(unsafe_entry)?;
                     // A hard link names an earlier entry of the same archive,
                     // so it is rooted at the rootfs like any other entry path.
@@ -288,18 +285,6 @@ pub(super) fn relative_display(root: &Path, path: &Path) -> String {
         .unwrap_or(path)
         .display()
         .to_string()
-}
-
-pub(super) fn is_supported(entry_type: EntryType) -> bool {
-    matches!(
-        entry_type,
-        EntryType::Regular
-            | EntryType::Directory
-            | EntryType::Symlink
-            | EntryType::Link
-            | EntryType::Continuous
-            | EntryType::GNUSparse
-    )
 }
 
 /// The target of a link entry, or `None` when the header does not name one.

--- a/source/src/extract/file.rs
+++ b/source/src/extract/file.rs
@@ -95,7 +95,7 @@ pub(super) fn unpack_regular<R: Read>(
 
     // `mode` is what the file was created with, but the umask applies to
     // creation and not to this, so it is still needed to get the mode asked for.
-    finish_file(&file, mode, entry.header().mtime().ok())?;
+    finish_file(&file, mode, crate::entries::mtime_of(entry.header()))?;
     Ok(replaced)
 }
 
@@ -103,11 +103,9 @@ pub(super) fn unpack_regular<R: Read>(
 ///
 /// The mode is applied again because the umask applies to creation but not to
 /// this, and it is the only way to end up with what the layer asked for.
-pub(super) fn finish_file(file: &fs::File, mode: u32, mtime: Option<u64>) -> io::Result<()> {
+pub(super) fn finish_file(file: &fs::File, mode: u32, mtime: u64) -> io::Result<()> {
     file.set_permissions(fs::Permissions::from_mode(mode))?;
-    if let Some(mtime) = mtime {
-        set_mtime(file, mtime);
-    }
+    set_mtime(file, mtime);
     Ok(())
 }
 
@@ -157,11 +155,9 @@ fn set_symlink_mtime(path: &Path, mtime: u64) {
 /// Links `dst` to wherever the entry pointed, and gives it the timestamp the
 /// entry carried. A symlink target is followed from where the link stands, so
 /// it is written exactly as the layer spelled it.
-pub(super) fn place_symlink(dst: &Path, target: &[u8], mtime: Option<u64>) -> io::Result<()> {
+pub(super) fn place_symlink(dst: &Path, target: &[u8], mtime: u64) -> io::Result<()> {
     std::os::unix::fs::symlink(Path::new(std::ffi::OsStr::from_bytes(target)), dst)?;
-    if let Some(mtime) = mtime {
-        set_symlink_mtime(dst, mtime);
-    }
+    set_symlink_mtime(dst, mtime);
     Ok(())
 }
 

--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -338,13 +338,13 @@ fn write_file(root: &Path, path: &mut PathBuf, entry: &Entry, body: &[u8]) -> Re
     // here means the plan and the tree have parted company.
     let (mut file, _) = create_file(path, entry.mode, Occupied::Refuse).io_context(context)?;
     file.write_all(body).io_context(context)?;
-    finish_file(&file, entry.mode, Some(entry.mtime)).io_context(context)
+    finish_file(&file, entry.mode, entry.mtime).io_context(context)
 }
 
 fn place_link(root: &Path, entry: &Entry) -> Result<()> {
     let mut path = PathBuf::new();
     resolve(root, &mut path, entry);
-    place_symlink(&path, &entry.link, Some(entry.mtime))
+    place_symlink(&path, &entry.link, entry.mtime)
         .io_context(|| format!("linking {:?}", String::from_utf8_lossy(&entry.path)))
 }
 

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -19,7 +19,6 @@ use crate::image::{Descriptor, Layout, hex_encode, parse_digest};
 use crate::zinfo;
 
 use super::RootfsExtractor;
-use super::entry::is_supported;
 use super::pipeline::{
     CHUNK_BYTES, Chunk, ChunkReader, PIPELINE_DEPTH, buffer_pool, compression_of, read_and_hash,
 };
@@ -46,17 +45,6 @@ fn known_layer_media_types_map_to_compression() {
         Some(Compression::Gzip)
     );
     assert_eq!(compression_of("application/vnd.oci.image.config.v1+json"), None);
-}
-
-#[test]
-fn device_entries_are_not_extracted() {
-    assert!(!is_supported(EntryType::Char));
-    assert!(!is_supported(EntryType::Block));
-    assert!(!is_supported(EntryType::Fifo));
-    assert!(is_supported(EntryType::Regular));
-    assert!(is_supported(EntryType::Symlink));
-    assert!(is_supported(EntryType::Link));
-    assert!(is_supported(EntryType::Directory));
 }
 
 #[test]


### PR DESCRIPTION
The walk decided what an entry was from its `EntryType`, with its own `is_supported` list; the entry table decided the same thing again as a `Kind`. The plan then reasons entirely in `Kind` about entries the walk treats by type, so the two lists had to be read side by side to be sure they said the same thing.

`Kind::of` is now the only classification, and the walk dispatches on it. `mode_of` and `mtime_of` join it: the mode was masked in three places and the timestamp was read two ways, `unwrap_or(0)` for the table against `.ok()` for the walk. A header whose timestamp will not parse therefore left the walk with the time of extraction and the span route with the epoch; both now take the epoch, which is at least the same answer.

Two consequences worth naming:

- The walk now skips a shadowed sparse file, because `Kind::is_file` covers sparse and the plan had always counted them as skippable. It used to write one and let a later layer replace it.
- `set_preserve_mtime` before `unpack_regular` did nothing: it only affects `tar`'s own unpacking, which regular files stopped using.

browserless/chromium extracts the same tree, byte for byte, 46,507 entries. Interleaved on disk, eight rounds: the walk costs about 0.6% more -- wall min 7.398 -> 7.451 s, med 7.576 -> 7.636 s, cpu min 10.413 -> 10.475 s, med 10.644 -> 10.706 s -- which is small, consistent, and the price of the two routes no longer being able to disagree. The span route is unchanged: wall min 2.297 -> 2.298 s.