### PR TITLE
fix: give a deferred mode only to a directory

### DIFF
--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -213,6 +213,13 @@ impl RootfsExtractor {
         self.deferred_modes
             .sort_by_key(|(path, _)| std::cmp::Reverse(path.components().count()));
         for (path, mode) in &self.deferred_modes {
+            // A later layer may have put something else at the path, and this
+            // is a directory's mode: applying it to whatever took its place
+            // would give that the directory's permissions instead of its own.
+            match fs::symlink_metadata(path) {
+                Ok(metadata) if metadata.is_dir() => {}
+                _ => continue,
+            }
             // Keep traversal rights: without them cleanup and later runs would fail.
             let mode = mode | 0o700;
             if let Err(err) = fs::set_permissions(path, fs::Permissions::from_mode(mode))

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -1516,6 +1516,28 @@ fn set_user_id_survives_extraction() {
     );
 }
 
+/// A directory's mode is applied once every layer has run, by which time a
+/// later layer may have put a file at that path. The file gets the mode its
+/// own entry asked for, not the one the directory wanted.
+#[test]
+fn a_file_replacing_a_directory_keeps_its_own_mode() {
+    for_each_route(
+        "file-over-directory",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "d/");
+                append_file(b, "d/gone", b"gone");
+            }),
+            tar_of(|b| append_file_moded(b, "d", b"file", 0o600)),
+        ],
+        |route, rootfs| {
+            let mode = fs::metadata(rootfs.join("d")).expect("stat").permissions().mode();
+            assert_eq!(mode & 0o7777, 0o600, "{route:?}: the mode the layer ships");
+        },
+    );
+}
+
 #[test]
 fn every_route_agrees_on_empty_files_and_layers() {
     assert_routes_agree(


### PR DESCRIPTION
Directory modes are applied once every layer has run, so that a read-only directory in one layer does not block writes from the next. By then a later layer may have replaced the directory with a file, and the mode was applied to whatever it found: a file at that path came out with the directory's permissions rather than its own, plus the `0o700` the deferral adds to keep the tree traversable.

The path is checked before the mode goes on. A symlink standing where a directory entry was is skipped too, since following it would give the directory's mode to whatever it points at.

Only the walk records modes this way, so only the walk had it: the plan records the directories the final tree holds, and a replaced path is not one of them. That is how the routes came to disagree.