### PR TITLE
fix: treat the planned directory tree as a head start, not a promise

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -131,13 +131,6 @@ impl RootfsExtractor {
                 continue;
             }
 
-            // A resolved image had its directory tree built before any layer
-            // ran, and a directory entry can only ask for one that is already
-            // there.
-            if kind == Kind::Directory && self.plan.is_resolved() {
-                continue;
-            }
-
             if !self.parents.prepare(&dst)? {
                 return Err(Error::UnsafeEntry {
                     layer: layer.to_string(),

--- a/source/src/extract/plan.rs
+++ b/source/src/extract/plan.rs
@@ -255,9 +255,12 @@ fn placeable(tree: &BTreeMap<&[u8], Node>, tables: &[Table]) -> Option<Work> {
             return None;
         }
         match node.kind {
+            // Nothing here is created under something that is not a directory,
+            // so whatever is there has to be resolved against the tree as it
+            // is built. That is the walk's job for the whole image.
+            _ if behind_a_link(tree, path) => return None,
             Kind::Directory | Kind::Unsupported => continue,
             Kind::Sparse => return None,
-            _ if behind_a_link(tree, path) => return None,
             Kind::File => work.files[layer].push(entry as u32),
             // A `BTreeMap` orders by path, so a link under another link is
             // already after it.

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -1042,6 +1042,28 @@ fn extract_by(
     Ok(rootfs)
 }
 
+/// Applies `layers` by the given route without holding it to a plan shape,
+/// and says whether the plan ended up placing the entries itself.
+fn apply_by(route: Route, root: &Utf8Path, layers: &[Vec<u8>]) -> (Result<Utf8PathBuf>, bool) {
+    let (index_dir, descriptors) = install_for(route, root, layers);
+    let rootfs = root.join("rootfs");
+    let dir = match route {
+        Route::Streaming => None,
+        Route::Planned | Route::Spans => Some(index_dir.as_path()),
+    };
+
+    let mut placed = false;
+    let applied = (|| {
+        let layout = Layout::open(root)?;
+        let mut extractor = RootfsExtractor::new(&rootfs, dir, true)?;
+        extractor.plan(&descriptors)?;
+        placed = extractor.plan.work().is_some();
+        extractor.apply(&layout, &descriptors)?;
+        extractor.finish()
+    })();
+    (applied.map(|()| rootfs), placed)
+}
+
 /// A rootfs reduced to sorted lines, so two of them can be compared and the
 /// first difference read directly.
 ///
@@ -1137,19 +1159,8 @@ fn assert_routes_agree(name: &str, routes: &[Route], layers: &[Vec<u8>]) {
 fn assert_routes_refuse(name: &str, layers: &[Vec<u8>]) {
     for route in Route::ALL {
         let root = scratch(&format!("{name}-{route:?}"));
-        let (index_dir, descriptors) = install_for(route, &root, layers);
-        let layout = Layout::open(&root).expect("layout");
-        let rootfs = root.join("rootfs");
-        let dir = match route {
-            Route::Streaming => None,
-            Route::Planned | Route::Spans => Some(index_dir.as_path()),
-        };
-
-        let mut extractor = RootfsExtractor::new(&rootfs, dir, true).expect("extractor");
-        let err = extractor
-            .plan(&descriptors)
-            .and_then(|()| extractor.apply(&layout, &descriptors))
-            .expect_err(&format!("{name}: {route:?} extracted what it must refuse"));
+        let (result, _) = apply_by(route, &root, layers);
+        let err = result.expect_err(&format!("{name}: {route:?} extracted what it must refuse"));
         assert!(
             matches!(err, Error::UnsafeEntry { .. }),
             "{name}: {route:?} expected an unsafe entry, got {err:?}"
@@ -1159,6 +1170,47 @@ fn assert_routes_refuse(name: &str, layers: &[Vec<u8>]) {
             "{name}: {route:?} wrote outside the rootfs"
         );
 
+        let _ = fsutil::force_remove_dir_all(root.as_std_path());
+    }
+}
+
+/// The plan builds the directory tree before any layer runs, and a whiteout
+/// later in the image removes what it built. The layer's own directory entry
+/// puts it back, so the walk cannot take the tree for granted.
+#[test]
+fn every_route_agrees_when_a_whiteout_takes_a_directory_a_later_entry_restores() {
+    assert_routes_agree(
+        "route-whiteout-then-directory",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "d/");
+                append_file(b, "d/gone", b"gone");
+            }),
+            tar_of(|b| {
+                append_file(b, ".wh.d", b"");
+                append_dir(b, "d/");
+            }),
+        ],
+    );
+}
+
+/// A layer cannot have a file at a path and a directory underneath it. The
+/// plan creates no directory behind something that is not one, so without
+/// this the fast routes quietly placed the file and dropped the rest.
+#[test]
+fn no_route_places_a_directory_under_a_file() {
+    let layers = [tar_of(|b| {
+        append_file(b, "d", b"file");
+        append_dir(b, "d/sub/");
+    })];
+    for route in Route::ALL {
+        let root = scratch(&format!("dir-under-file-{route:?}"));
+        let (result, _) = apply_by(route, &root, &layers);
+        assert!(
+            matches!(result, Err(Error::Io { .. })),
+            "{route:?}: expected the directory to be refused, got {result:?}"
+        );
         let _ = fsutil::force_remove_dir_all(root.as_std_path());
     }
 }


### PR DESCRIPTION
A resolved plan made the walk skip every directory entry, on the grounds that the tree had already been built. The tree it builds is the one the final image holds, which is not the same thing:

- a whiteout later in the image removes a directory the plan created, and the entry that puts it back was the one being skipped, so the directory was simply gone;
- the plan deliberately creates nothing behind something that is not a directory, so a directory there was never created by anyone.

The walk now places directory entries whatever the plan did. Creating one that is already there costs a `stat` and a failed `mkdir` per directory entry, on the one route that both resolves a plan and walks.

`placeable` also declines an image holding anything behind a non-directory, where before it only declined for files: a directory under a file is an image nobody can extract, and the walk is what says so, while a directory under a symlink has to be created through the link. Either way the fast route was quietly placing what it could and dropping the rest.

Found by generating small images and comparing the routes, which is the commit after this one. browserless/chromium still plans, still 299 units.