### PR TITLE
fix: clear the path a skipped body would have taken

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -125,17 +125,23 @@ impl RootfsExtractor {
             // work of the layers below whatever the plan does with the entry.
             self.written.insert(dst.clone());
 
-            // A body a later layer replaces is written and then thrown away,
-            // so the plan takes it out before any of that happens.
-            if kind.is_file() && self.plan.is_shadowed(layer, &relative) {
-                continue;
-            }
-
             if !self.parents.prepare(&dst)? {
                 return Err(Error::UnsafeEntry {
                     layer: layer.to_string(),
                     path: path.display().to_string(),
                 });
+            }
+
+            // A body a later layer replaces is written and then thrown away,
+            // so the plan takes it out before any of that happens. What
+            // writing it would have cleared away still goes: only bodies are
+            // skipped, so a directory standing here was never planned away
+            // and would be left for a write that no longer happens.
+            if kind.is_file() && self.plan.is_shadowed(layer, &relative) {
+                if fsutil::remove_any(&dst)? {
+                    self.parents.forget(&dst);
+                }
+                continue;
             }
 
             let mode = mode_of(entry.header());

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -942,6 +942,27 @@ fn a_planned_image_still_applies_its_whiteouts() {
     let _ = fsutil::force_remove_dir_all(root.as_std_path());
 }
 
+/// A body a later layer replaces is skipped, and writing it would have taken
+/// the directory standing at that path with it. Only bodies are skipped, so
+/// the directories underneath were never planned away: they were left for the
+/// write that no longer happens, and a later directory entry keeps a directory
+/// it finds standing.
+#[test]
+fn every_route_agrees_when_a_skipped_body_would_have_cleared_a_directory() {
+    assert_routes_agree(
+        "route-skipped-body-clears",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "d/");
+                append_dir(b, "d/sub/");
+            }),
+            tar_of(|b| append_file(b, "d", b"file")),
+            tar_of(|b| append_dir(b, "d/")),
+        ],
+    );
+}
+
 /// The ways a layer set can reach the rootfs. Which one runs is decided by
 /// what sidecars sit beside the blobs, so a fixture can be put through all
 /// three and the results compared.


### PR DESCRIPTION
An entry a later layer replaces is not written: the plan says so and the walk skips it. Skipping the write also skips what the write would have cleared away, and a directory standing at that path is not something the plan takes out, because only bodies are ever skipped.

So a layer replacing a directory with a file, where a later layer replaces that file again, left the directory and everything under it standing on any route that resolved a plan, and a later directory entry keeps a directory it finds. The walk without sidecars had removed the lot.

The path is cleared before the body is skipped, which is what writing it would have done.