### PR TITLE
fix: keep a directory an opaque marker's own layer wrote into

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -247,9 +247,11 @@ impl RootfsExtractor {
 
     /// Removes everything under `dir` that this layer did not put there.
     ///
-    /// A path this layer wrote stays, and so does the directory holding it,
-    /// which is why this walks down rather than clearing the level and
-    /// stopping.
+    /// A path this layer wrote stays, and so does the directory holding it —
+    /// including one no entry names, made only to hold what went in it. What
+    /// the layer wrote is taken from the record rather than from the disk: a
+    /// body the plan skipped counts as written, and the directory it would
+    /// have gone in is still one to keep.
     fn clear_lower_layers(&mut self, dir: &Path) -> Result<()> {
         let entries = match fs::read_dir(dir) {
             Ok(entries) => entries,
@@ -260,14 +262,15 @@ impl RootfsExtractor {
         for entry in entries {
             let entry = entry.io_context(|| format!("listing {}", dir.display()))?;
             let path = entry.path();
+            let is_dir = entry
+                .file_type()
+                .io_context(|| format!("inspecting {}", path.display()))?
+                .is_dir();
+            if is_dir && (self.written.contains(&path) || self.wrote_under(&path)) {
+                keep.push(path);
+                continue;
+            }
             if self.written.contains(&path) {
-                if entry
-                    .file_type()
-                    .io_context(|| format!("inspecting {}", path.display()))?
-                    .is_dir()
-                {
-                    keep.push(path);
-                }
                 continue;
             }
             fsutil::remove_any(&path)?;
@@ -276,6 +279,14 @@ impl RootfsExtractor {
             self.clear_lower_layers(&path)?;
         }
         Ok(())
+    }
+
+    /// True when this layer has placed anything under `dir`.
+    fn wrote_under(&self, dir: &Path) -> bool {
+        self.written
+            .range(dir.to_path_buf()..)
+            .take_while(|path| path.starts_with(dir))
+            .any(|path| path != dir)
     }
 }
 

--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -14,7 +14,7 @@ mod spans;
 mod tests;
 mod whiteout;
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs;
 use std::io;
 use std::os::unix::fs::PermissionsExt;
@@ -43,8 +43,10 @@ pub struct RootfsExtractor {
     parents: fsutil::ParentCache,
     plan: plan::Plan,
     /// What the layer currently being walked has placed. A whiteout hides the
-    /// layers below it, so it has to be able to tell them apart.
-    written: HashSet<PathBuf>,
+    /// layers below it, so it has to be able to tell them apart. Ordered, so
+    /// that a directory can be asked whether anything of this layer's is under
+    /// it, which is what keeps one it made to hold an entry.
+    written: BTreeSet<PathBuf>,
     /// Refuse an image that asks for extended attributes, rather than
     /// extracting one the container will not match.
     strict_xattrs: bool,
@@ -63,7 +65,7 @@ impl RootfsExtractor {
             index_dir: index_dir.map(Utf8Path::to_owned),
             deferred_modes: Vec::new(),
             plan: plan::Plan::default(),
-            written: HashSet::new(),
+            written: BTreeSet::new(),
             strict_xattrs,
         })
     }

--- a/source/src/extract/tests.rs
+++ b/source/src/extract/tests.rs
@@ -963,6 +963,39 @@ fn every_route_agrees_when_a_skipped_body_would_have_cleared_a_directory() {
     );
 }
 
+/// An opaque marker clears what the layers below left in a directory. A
+/// directory this layer made only to hold something it wrote is not one of
+/// those, and nothing names it, so it was cleared along with the file inside
+/// it.
+#[test]
+fn an_opaque_whiteout_keeps_a_directory_holding_this_layer_s_work() {
+    for_each_route(
+        "opaque-keeps-implicit-parent",
+        &Route::ALL,
+        &[
+            tar_of(|b| {
+                append_dir(b, "d/");
+                append_file(b, "d/old", b"old");
+            }),
+            tar_of(|b| {
+                append_file(b, "d/sub/z", b"z");
+                append_file(b, "d/.wh..wh..opq", b"");
+            }),
+        ],
+        |route, rootfs| {
+            assert_eq!(
+                fs::read_to_string(rootfs.join("d/sub/z")).unwrap_or_default(),
+                "z",
+                "{route:?} cleared what this layer wrote"
+            );
+            assert!(
+                !rootfs.join("d/old").exists(),
+                "{route:?} kept what the marker hides"
+            );
+        },
+    );
+}
+
 /// The ways a layer set can reach the rootfs. Which one runs is decided by
 /// what sidecars sit beside the blobs, so a fixture can be put through all
 /// three and the results compared.


### PR DESCRIPTION
An opaque marker empties a directory of what the layers below put there. What this layer put there stays, and so does whatever is holding it -- but a directory made only to hold an entry is named by nobody, so it was not in the set of paths the layer had written, and it went, taking the file inside it with it.

The set is ordered now, so a directory can be asked whether anything of this layer's is under it. Asking the filesystem instead -- clear the directory and keep the one that will not go -- is cheaper and wrong: a body the plan skipped is still the layer's work, and the directory it would have gone in is still one to keep, but on disk it is empty.