### PR TITLE
Ask a set for a range without allocating the key

### DIFF
--- a/source/src/extract/entry.rs
+++ b/source/src/extract/entry.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 use std::io::{self, Read};
+use std::ops::Bound;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
@@ -291,7 +292,7 @@ impl RootfsExtractor {
     /// True when this layer has placed anything under `dir`.
     fn wrote_under(&self, dir: &Path) -> bool {
         self.written
-            .range(dir.to_path_buf()..)
+            .range::<Path, _>((Bound::Included(dir), Bound::Unbounded))
             .take_while(|path| path.starts_with(dir))
             .any(|path| path != dir)
     }

--- a/source/src/fsutil.rs
+++ b/source/src/fsutil.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::ffi::OsStr;
 use std::fs;
 use std::io;
+use std::ops::Bound;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -225,7 +226,7 @@ impl ParentCache {
     pub fn forget(&mut self, path: &Path) {
         let doomed: Vec<PathBuf> = self
             .verified
-            .range(path.to_path_buf()..)
+            .range::<Path, _>((Bound::Included(path), Bound::Unbounded))
             .take_while(|p| p.starts_with(path))
             .cloned()
             .collect();


### PR DESCRIPTION
`BTreeSet::range` takes a bound by borrow when it is told the key type, so `path..` on a `&Path` needs no owned copy of the path to name where the range starts. Both callers were building one:

- `ParentCache::forget` runs for every entry a later layer replaces and for every removal a whiteout makes -- 17,755 replaced files on chromium alone -- and in the usual case the range is empty, so the discarded `PathBuf` was the only allocation the call made.
- `wrote_under` runs once per directory under an opaque marker.

`plan.rs` already asks its byte-keyed trees this way in `holds_anything`; this is the same shape for the two path-keyed sets.

No behaviour change: `(Included(path), Unbounded)` is the range `path..` spells, and `take_while` still bounds it to the subtree.