### PR TITLE
Let the descriptors be read where they are rather than copied

### DIFF
--- a/source/src/extract/mod.rs
+++ b/source/src/extract/mod.rs
@@ -196,37 +196,41 @@ impl RootfsExtractor {
         }
 
         let file = layout.open_blob(descriptor)?;
-        let digest = descriptor.digest.clone();
+        let digest = &descriptor.digest;
         let (sender, receiver) = sync_channel(PIPELINE_DEPTH);
         let (pool, ret) = buffer_pool();
         // Indexed spans are sized by the index rather than by CHUNK_BYTES, so
         // there is nothing for the streaming pool to hand them back to.
         let ret = index.is_none().then_some(ret);
-        let owned = descriptor.clone();
-        let inflate = thread::spawn(move || match index {
-            Some(index) => inflate_indexed(file, &index, &owned, Sink::new(sender)),
-            None => inflate_blob(file, &owned, Sink::new(sender), pool),
-        });
+        // Scoped, so the inflater reads the caller's descriptor and index
+        // where a detached thread would have needed copies of both.
+        thread::scope(|scope| {
+            let index = &index;
+            let inflate = scope.spawn(move || match index {
+                Some(index) => inflate_indexed(file, index, descriptor, Sink::new(sender)),
+                None => inflate_blob(file, descriptor, Sink::new(sender), pool),
+            });
 
-        let mut reader = ChunkReader::new(receiver, ret);
-        let mut unpacked = self.unpack(&mut reader, &digest);
-        if unpacked.is_ok() {
-            // The tar stream ends at its marker, but the digest covers the blob.
-            unpacked = io::copy(&mut reader, &mut io::sink())
-                .map(|_| ())
-                .io_context(|| format!("reading layer {digest}"));
-        }
-        // Releasing the receiver lets the inflater stop early when unpacking failed.
-        drop(reader);
+            let mut reader = ChunkReader::new(receiver, ret);
+            let mut unpacked = self.unpack(&mut reader, digest);
+            if unpacked.is_ok() {
+                // The tar stream ends at its marker, but the digest covers the blob.
+                unpacked = io::copy(&mut reader, &mut io::sink())
+                    .map(|_| ())
+                    .io_context(|| format!("reading layer {digest}"));
+            }
+            // Releasing the receiver lets the inflater stop early when unpacking failed.
+            drop(reader);
 
-        match inflate.join() {
-            // An unverified blob explains any unpacking failure, so it wins.
-            Ok(inflated) => inflated.and(unpacked),
-            Err(_) => Err(Error::io(
-                "decompressing a layer",
-                io::Error::other("the decompression thread panicked"),
-            )),
-        }
+            match inflate.join() {
+                // An unverified blob explains any unpacking failure, so it wins.
+                Ok(inflated) => inflated.and(unpacked),
+                Err(_) => Err(Error::io(
+                    "decompressing a layer",
+                    io::Error::other("the decompression thread panicked"),
+                )),
+            }
+        })
     }
 
     /// Applies the recorded directory permissions, deepest first.

--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -36,8 +36,8 @@ use super::file::{place_body, place_hard_link, place_link};
 use super::plan::{Plan, Work};
 
 /// Everything one layer contributes, held open for the length of the run.
-struct Layer {
-    descriptor: Descriptor,
+struct Layer<'a> {
+    descriptor: &'a Descriptor,
     blob: Blob,
     index: zinfo::Index,
 }
@@ -132,17 +132,17 @@ pub fn extract(
     Ok(())
 }
 
-fn open_layers(
+fn open_layers<'a>(
     layout: &Layout,
-    descriptors: &[Descriptor],
+    descriptors: &'a [Descriptor],
     indexes: Vec<zinfo::Index>,
-) -> Result<Vec<Layer>> {
+) -> Result<Vec<Layer<'a>>> {
     descriptors
         .iter()
         .zip(indexes)
         .map(|(descriptor, index)| {
             Ok(Layer {
-                descriptor: descriptor.clone(),
+                descriptor,
                 blob: layout.map_blob(descriptor)?,
                 index,
             })


### PR DESCRIPTION
A `Descriptor` carries two `String`s, and the layer slice one comes from outlives every reader of it. Two places copied one anyway:

- `spans::Layer` owned a clone per layer, though `open_layers` is handed the slice and the layers do not outlive the call that made them. It now borrows.
- `apply_layer` cloned the descriptor and its digest to satisfy the `'static` bound of `thread::spawn`. The inflater does not outlive the call either, so `thread::scope` lets it read both in place.

The scope joins the inflater by hand as before, so a panicking inflater is still reported as one rather than re-raised: a thread joined explicitly is not one the scope joins for you.

Small in absolute terms -- three `String` allocations per layer -- but the ownership now says what is true, which is that a layer is described by the manifest for the whole run.