### PR TITLE
feat(bench): committed tooling for measuring the launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,17 +46,30 @@ from the behavioural change.
 
 ## Benchmarking
 
-Launcher performance is the recurring workstream, so measure it properly:
+Launcher performance is the recurring workstream, so use the committed tools
+rather than writing another one-off script. See
+[source/README.md](source/README.md#benchmarking); in short:
 
-- Use an optimised release build (`--config=release`).
-- Report CPU time (user + sys) and syscall counts. Wall clock is unreliable in
-  containers and VMs.
-- Interleave old and new binaries round robin; report min, median and max.
-- Benchmark on an image rich in symlinks and overwrites, not just a distro base.
-  A per entry cache regression that was invisible on alpine cost 5x on
-  `browserless/chromium`.
-- Confirm the fast run actually did the work (entry counts, exit codes) and diff
-  the extracted trees before believing a speedup.
+```
+cd source && bazel build //:bench_image //:bench_run
+.bazel/bin/bench_image --output /tmp/bench-full --profile full
+.bazel/bin/bench_run --layout /tmp/bench-full --rounds 7 --syscalls OLD NEW
+```
+
+- Build with `--config=release`; run outside Bazel.
+- Prefer counts to times. Syscall counts and entries placed do not care what
+  else the host was doing; wall clock in a container or VM does.
+- Anything under 2% is this host, not the change. Prove it by passing the same
+  binary to `bench_run` twice before believing a number near the floor.
+- Absolute numbers do not survive a reboot. Only within-run comparisons mean
+  anything.
+- Confirm the fast run did the work: `bench_run` counts the entries every run
+  placed and says so when they disagree.
+- A harness that skips the work a design introduces will flatter that design.
+  The parallel writer looked 5x better than it was for exactly this reason.
+- `//:bench_counts_test` guards the counts in CI. When it fails, something
+  changed what the launcher asks of the kernel -- find out what before
+  updating its numbers.
 
 ## Git
 

--- a/source/BUILD.bazel
+++ b/source/BUILD.bazel
@@ -6,7 +6,31 @@ exports_files(["rustfmt.toml"])
 
 rust_binary(
     name = "oci_runtime",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(
+        ["src/**/*.rs"],
+        exclude = ["src/bin/**"],
+    ),
+    aliases = aliases(),
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = all_crate_deps(normal = True),
+)
+
+# Benchmarking tools are built by Bazel and then run outside it: a measurement
+# taken through the sandbox, with its own filesystem layout and resource
+# limits, is not the measurement anyone cares about.
+rust_binary(
+    name = "bench_image",
+    srcs = ["src/bin/bench_image.rs"],
+    aliases = aliases(),
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = all_crate_deps(normal = True),
+)
+
+rust_binary(
+    name = "bench_run",
+    srcs = ["src/bin/bench_run.rs"],
     aliases = aliases(),
     edition = "2024",
     visibility = ["//visibility:public"],
@@ -19,10 +43,32 @@ rust_test(
     crate = ":oci_runtime",
 )
 
+# Counts, never times. A CI runner's clock is useless for this, but a syscall
+# the launcher stopped making is a syscall it stopped making on any host.
+rust_test(
+    name = "bench_counts_test",
+    timeout = "short",
+    srcs = ["tests/counts.rs"],
+    data = [
+        ":bench_image",
+        ":oci_runtime",
+    ],
+    edition = "2024",
+    env = {
+        "BENCH_IMAGE": "$(rootpath :bench_image)",
+        "OCI_RUNTIME": "$(rootpath :oci_runtime)",
+    },
+)
+
 rustfmt_test(
     name = "oci_runtime_fmt_test",
     timeout = "short",
-    targets = [":oci_runtime"],
+    targets = [
+        ":bench_counts_test",
+        ":bench_image",
+        ":bench_run",
+        ":oci_runtime",
+    ],
 )
 
 launcher_toolchain(

--- a/source/Cargo.Bazel.lock
+++ b/source/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e71783b6fd9b18f1bb5f2f0fd524d11f6747ed8c9c1cfe5b0b6de4e801c0dd6f",
+  "checksum": "f5cd6895250af2ab6e0526072f964375bf32cdf033d0beb962a2defbac0b43fe",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",

--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -11,6 +11,14 @@ edition = "2024"
 name = "oci_runtime"
 path = "src/main.rs"
 
+[[bin]]
+name = "bench_image"
+path = "src/bin/bench_image.rs"
+
+[[bin]]
+name = "bench_run"
+path = "src/bin/bench_run.rs"
+
 [dependencies]
 camino = "1.2.5"
 clap = { version = "4.6.3", features = ["derive"] }

--- a/source/README.md
+++ b/source/README.md
@@ -21,3 +21,46 @@ build --@rules_oci_runtime//lib:prebuilt_launcher=false
 
 See the top-level [README](../README.md#how-it-works) for what the launcher
 does at run time.
+
+## Benchmarking
+
+Two tools, built by Bazel and run outside it. Running them through `bazel run`
+would measure the sandbox as much as the launcher, so build first and invoke
+the binaries directly:
+
+```
+bazel build //:bench_image //:bench_run
+.bazel/bin/bench_image --output /tmp/bench-full --profile full
+.bazel/bin/bench_run --layout /tmp/bench-full --rounds 7 old/oci_runtime new/oci_runtime
+```
+
+`bench_image` writes a deterministic image layout. The seed is the whole
+reproduction: the same seed and profile give byte identical blobs. The `full`
+profile is shaped like the image this launcher is actually slow on -- a long
+tail of small files with a few very large ones holding most of the bytes,
+seven thousand directories, and three bytes shadowed by a later layer for every
+two that survive. A distribution base image has none of that, and a per entry
+regression that was invisible on alpine once cost 5x on a real image.
+
+`bench_run` compares binaries against one layout. It builds each binary's own
+sidecars, reports the route each one took and refuses to compare two that
+disagree, discards a warmup, interleaves the timed rounds and reverses their
+order every other round. It reports counts beside the times, and says "within
+noise" rather than printing a number too small to attribute.
+
+Pass `--syscalls` for a separate `strace -c` pass; syscall counts do not move
+when the host is busy, so a difference of one is a difference. `--perf` adds
+instructions retired where the host allows it.
+
+Passing the same binary twice is how to find out what this host's floor is
+today:
+
+```
+.bazel/bin/bench_run --layout /tmp/bench-full --rounds 7 \
+    .bazel/bin/oci_runtime .bazel/bin/oci_runtime
+```
+
+`//:bench_counts_test` holds the same counts in CI, where the clock is worth
+nothing: entries placed, what the plan skipped, and the syscalls each route
+makes. Its numbers come from `bench_image --profile small`; when the generator
+changes, run the test and update them from what it reports.

--- a/source/src/bin/bench_image.rs
+++ b/source/src/bin/bench_image.rs
@@ -1,0 +1,825 @@
+//! Builds a deterministic OCI image layout to benchmark the launcher against.
+//!
+//! The reference workload has always been a pulled image (`browserless/chromium`),
+//! which cannot be reproduced from this repository and does not survive a
+//! machine. What matters about it is the *shape* rather than the contents: a
+//! long tail of small files with a handful of very large ones carrying most of
+//! the bytes, thousands of directories, plenty of symlinks, and far more bodies
+//! shadowed by a later layer than survive into the tree. A distribution base
+//! image has none of that, and a per entry cache regression that was invisible
+//! on alpine cost 5x on chromium.
+//!
+//! The seed is the whole reproduction: the same seed and profile produce byte
+//! identical blobs, so a digest recorded in a test stays valid.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use clap::{Parser, ValueEnum};
+use flate2::{Compression, GzBuilder};
+use sha2::{Digest, Sha256};
+
+/// Every timestamp is fixed so the layout is reproducible.
+const MTIME: u64 = 1_700_000_000;
+
+const GZIP_LAYER: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+const OCI_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
+const OCI_CONFIG: &str = "application/vnd.oci.image.config.v1+json";
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "bench_image",
+    about = "Generate a deterministic OCI image layout for benchmarking"
+)]
+struct Args {
+    /// Directory to write the layout into. Replaced if it exists.
+    #[arg(long, value_name = "DIR")]
+    output: Utf8PathBuf,
+
+    /// Size and shape of the generated image.
+    #[arg(long, value_enum, default_value_t = Profile::Full)]
+    profile: Profile,
+
+    /// Changing this changes every path, size and body in the image.
+    #[arg(long, default_value_t = 1)]
+    seed: u64,
+
+    /// Layers compressed at once. Each worker holds one whole layer.
+    #[arg(long, value_name = "N")]
+    workers: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Profile {
+    /// Roughly the shape of the reference image: ~8k files, ~500 MiB.
+    Full,
+    /// A tenth of the size, for iterating on the harness itself.
+    Medium,
+    /// Seconds to build and small enough for a test to extract.
+    Small,
+}
+
+/// What the profile asks for. Counts are targets, not guarantees: an entry
+/// that would collide with something the generator already placed is skipped.
+struct Shape {
+    layers: usize,
+    directories: usize,
+    /// Paths written for the first time, across all layers.
+    files: usize,
+    /// Writes to a path an earlier layer already wrote, whose body the tree
+    /// never keeps. The reference image shadows three bodies for every one it
+    /// keeps, and the span route exists to skip exactly these.
+    rewrites: usize,
+    /// Multiplies every body size, so the shape of the distribution is the
+    /// same at every profile.
+    scale: f64,
+}
+
+impl Profile {
+    fn shape(self) -> Shape {
+        match self {
+            Profile::Full => Shape {
+                layers: 20,
+                directories: 7_000,
+                files: 8_000,
+                rewrites: 23_000,
+                scale: 1.0,
+            },
+            Profile::Medium => Shape {
+                layers: 12,
+                directories: 900,
+                files: 1_200,
+                rewrites: 3_000,
+                scale: 0.12,
+            },
+            Profile::Small => Shape {
+                layers: 6,
+                directories: 60,
+                files: 120,
+                rewrites: 240,
+                scale: 0.05,
+            },
+        }
+    }
+}
+
+/// SplitMix64. Ten lines, no dependency, and the seed is the whole
+/// reproduction for any image it produces.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed ^ 0x243f_6a88_85a3_08d3)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+
+    fn pick<'a, T>(&mut self, from: &'a [T]) -> &'a T {
+        &from[self.below(from.len())]
+    }
+
+    /// Uniform in `[0, 1)`.
+    fn unit(&mut self) -> f64 {
+        (self.next() >> 11) as f64 / (1u64 << 53) as f64
+    }
+}
+
+const WORDS: [&str; 24] = [
+    "lib",
+    "bin",
+    "share",
+    "src",
+    "include",
+    "python3",
+    "site",
+    "packages",
+    "node",
+    "modules",
+    "chrome",
+    "locales",
+    "resources",
+    "icons",
+    "hicolor",
+    "fonts",
+    "truetype",
+    "doc",
+    "man",
+    "etc",
+    "conf",
+    "data",
+    "cache",
+    "build",
+];
+
+const EXTENSIONS: [&str; 10] = [
+    "so", "py", "js", "json", "png", "txt", "h", "pak", "dat", "xml",
+];
+
+const MODES: [u32; 4] = [0o644, 0o644, 0o755, 0o600];
+
+#[derive(Debug, Clone)]
+enum Kind {
+    Directory,
+    /// `seed` reproduces the body without storing it.
+    File {
+        size: usize,
+        mode: u32,
+        seed: u64,
+    },
+    Symlink {
+        target: String,
+    },
+    /// Always names a path this same layer already wrote, which is what a
+    /// real archiver emits and what keeps the target resolvable.
+    HardLink {
+        target: String,
+    },
+    /// A `.wh.` marker; `path` is already the marker's own path.
+    Whiteout,
+    /// A `.wh..wh..opq` marker.
+    Opaque,
+}
+
+struct Entry {
+    path: String,
+    kind: Kind,
+}
+
+/// What the generator decided, reported so a run can be described without
+/// unpacking the layout again.
+#[derive(Default)]
+struct Counts {
+    directories: usize,
+    files: usize,
+    symlinks: usize,
+    hard_links: usize,
+    whiteouts: usize,
+    /// Uncompressed body bytes across every layer, shadowed ones included.
+    bytes: u64,
+    /// Body bytes a later layer overwrites, so the tree never keeps them.
+    shadowed_bytes: u64,
+}
+
+fn main() {
+    let args = Args::parse();
+    if let Err(err) = build(&args) {
+        eprintln!("bench_image: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn build(args: &Args) -> io::Result<()> {
+    let shape = args.profile.shape();
+    let (layers, counts) = plan(args.seed, &shape);
+
+    if args.output.exists() {
+        fs::remove_dir_all(&args.output)?;
+    }
+    fs::create_dir_all(args.output.join("blobs/sha256"))?;
+
+    let workers = args
+        .workers
+        .unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1)
+        })
+        .clamp(1, layers.len().max(1))
+        // Each worker holds a whole layer, uncompressed and compressed.
+        .min(4);
+
+    let built = compress(&layers, &args.output, workers)?;
+
+    let diff_ids: Vec<String> = built.iter().map(|blob| blob.diff_id.clone()).collect();
+    let config = serde_json::json!({
+        "architecture": host_architecture(),
+        "os": "linux",
+        "config": {"Cmd": ["/bin/sh"]},
+        "rootfs": {"type": "layers", "diff_ids": diff_ids},
+    });
+    let (config_digest, config_size) = write_blob(&args.output, &serde_json::to_vec(&config)?)?;
+
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": OCI_MANIFEST,
+        "config": {
+            "mediaType": OCI_CONFIG,
+            "digest": config_digest,
+            "size": config_size,
+        },
+        "layers": built.iter().map(|blob| serde_json::json!({
+            "mediaType": GZIP_LAYER,
+            "digest": blob.digest,
+            "size": blob.size,
+        })).collect::<Vec<_>>(),
+    });
+    let (manifest_digest, manifest_size) =
+        write_blob(&args.output, &serde_json::to_vec(&manifest)?)?;
+
+    let index = serde_json::json!({
+        "schemaVersion": 2,
+        "manifests": [{
+            "mediaType": OCI_MANIFEST,
+            "digest": manifest_digest,
+            "size": manifest_size,
+            "platform": {"architecture": host_architecture(), "os": "linux"},
+        }],
+    });
+    fs::write(args.output.join("index.json"), serde_json::to_vec(&index)?)?;
+    fs::write(
+        args.output.join("oci-layout"),
+        br#"{"imageLayoutVersion":"1.0.0"}"#,
+    )?;
+
+    // Recorded beside the layout so a harness can report what it measured
+    // against without reading every blob back.
+    let compressed: u64 = built.iter().map(|blob| blob.size).sum();
+    let fixture = serde_json::json!({
+        "seed": args.seed,
+        "profile": format!("{:?}", args.profile).to_lowercase(),
+        "manifest": manifest_digest,
+        "layers": built.len(),
+        "directories": counts.directories,
+        "files": counts.files,
+        "symlinks": counts.symlinks,
+        "hardLinks": counts.hard_links,
+        "whiteouts": counts.whiteouts,
+        "uncompressedBytes": counts.bytes,
+        "shadowedBytes": counts.shadowed_bytes,
+        "compressedBytes": compressed,
+    });
+    fs::write(
+        args.output.join("bench-fixture.json"),
+        serde_json::to_vec_pretty(&fixture)?,
+    )?;
+
+    eprintln!(
+        "{} layers, {} directories, {} files ({} symlinks, {} hard links, {} whiteouts)",
+        built.len(),
+        counts.directories,
+        counts.files,
+        counts.symlinks,
+        counts.hard_links,
+        counts.whiteouts,
+    );
+    eprintln!(
+        "{} of bodies, {} of them shadowed, {} compressed",
+        human(counts.bytes),
+        human(counts.shadowed_bytes),
+        human(compressed),
+    );
+    println!("{manifest_digest}");
+    Ok(())
+}
+
+/// Decides every entry of every layer up front. Bodies are not materialised
+/// here, so the whole plan for the full profile costs a few megabytes and the
+/// layers can then be built in any order.
+fn plan(seed: u64, shape: &Shape) -> (Vec<Vec<Entry>>, Counts) {
+    let mut rng = Rng::new(seed);
+    let mut counts = Counts::default();
+
+    let directories = directories(&mut rng, shape.directories);
+    let mut layers: Vec<Vec<Entry>> = (0..shape.layers).map(|_| Vec::new()).collect();
+
+    // The base layer carries most of the tree, as a real image's does.
+    let base = directories.len() * 3 / 5;
+    let mut visible: Vec<&str> = Vec::new();
+    let mut next_directory = 0;
+
+    // Paths holding a body and how big it is, so a rewrite has something to
+    // shadow and a whiteout something to remove.
+    let mut live: Vec<(String, usize)> = Vec::new();
+    let mut taken: BTreeSet<String> = BTreeSet::new();
+    // Hard links and the copies they name. The plan refuses an image whose
+    // hard link target the final tree does not hold, so nothing may remove
+    // one of these.
+    let mut pinned: Vec<String> = Vec::new();
+    let mut opaque_done = false;
+
+    for layer in 0..shape.layers {
+        let entries = &mut layers[layer];
+
+        let wanted = if layer == 0 {
+            base
+        } else {
+            next_directory + (directories.len() - base) / (shape.layers - 1)
+        }
+        .min(directories.len());
+        for directory in &directories[next_directory..wanted] {
+            entries.push(Entry {
+                path: directory.clone(),
+                kind: Kind::Directory,
+            });
+            visible.push(directory.as_str());
+            counts.directories += 1;
+        }
+        next_directory = wanted;
+
+        // Half the new files land in the base layer, as does most of the tree.
+        let new_files = if layer == 0 {
+            shape.files / 2
+        } else {
+            shape.files / 2 / (shape.layers - 1)
+        };
+        let rewrites = if layer == 0 {
+            0
+        } else {
+            shape.rewrites / (shape.layers - 1)
+        };
+
+        for _ in 0..new_files {
+            if visible.is_empty() {
+                break;
+            }
+            let directory = *rng.pick(&visible);
+            let path = format!("{directory}/{}", file_name(&mut rng));
+            if !taken.insert(path.clone()) {
+                continue;
+            }
+            match rng.below(100) {
+                // Symlinks are dense in the reference image, and the whole
+                // path resolver hangs off them.
+                0..=7 => {
+                    let target = if live.is_empty() || rng.below(2) == 0 {
+                        "../".repeat(rng.below(3)) + &file_name(&mut rng)
+                    } else {
+                        rng.pick(&live).0.clone()
+                    };
+                    entries.push(Entry {
+                        path,
+                        kind: Kind::Symlink { target },
+                    });
+                    counts.symlinks += 1;
+                }
+                8..=9 => {
+                    // A hard link resolves against the tree as it stands, so
+                    // it names something this layer has already written.
+                    let target = entries.iter().rev().find_map(|entry| match entry.kind {
+                        Kind::File { .. } => Some(entry.path.clone()),
+                        _ => None,
+                    });
+                    match target {
+                        Some(target) => {
+                            // The plan refuses an image whose hard link names
+                            // a copy a later layer replaces or removes, and
+                            // that would drop the whole fixture onto the walk.
+                            live.retain(|(path, _)| path != &target);
+                            pinned.push(target.clone());
+                            pinned.push(path.clone());
+                            entries.push(Entry {
+                                path,
+                                kind: Kind::HardLink { target },
+                            });
+                            counts.hard_links += 1;
+                        }
+                        None => continue,
+                    }
+                }
+                _ => {
+                    let size = body_size(&mut rng, shape.scale, true);
+                    entries.push(Entry {
+                        path: path.clone(),
+                        kind: Kind::File {
+                            size,
+                            mode: *rng.pick(&MODES),
+                            seed: rng.next(),
+                        },
+                    });
+                    counts.bytes += size as u64;
+                    counts.files += 1;
+                    live.push((path, size));
+                }
+            }
+        }
+
+        // A rewrite is a small file changing between layers. Letting one land
+        // on a multi-megabyte file would shadow away most of the image's bytes
+        // and leave a tree far smaller than the layers that built it.
+        let ceiling = (256_000.0 * shape.scale) as usize;
+        for _ in 0..rewrites {
+            if live.is_empty() {
+                break;
+            }
+            let mut index = rng.below(live.len());
+            for _ in 0..3 {
+                if live[index].1 <= ceiling {
+                    break;
+                }
+                index = rng.below(live.len());
+            }
+            let size = body_size(&mut rng, shape.scale, false);
+            entries.push(Entry {
+                path: live[index].0.clone(),
+                kind: Kind::File {
+                    size,
+                    mode: *rng.pick(&MODES),
+                    seed: rng.next(),
+                },
+            });
+            live[index].1 = size;
+            counts.bytes += size as u64;
+        }
+
+        if layer > 0 && !live.is_empty() {
+            for _ in 0..(live.len() / 200).max(1) {
+                let index = rng.below(live.len());
+                let (path, _) = live.swap_remove(index);
+                entries.push(Entry {
+                    path: whiteout_of(&path),
+                    kind: Kind::Whiteout,
+                });
+                counts.whiteouts += 1;
+            }
+        }
+
+        // One opaque marker, mid image, over a directory with contents to
+        // remove. It is the case that has broken the plan twice. Deep enough
+        // that it does not take most of the tree with it.
+        if !opaque_done && layer == shape.layers / 2 {
+            let deep: Vec<&str> = visible
+                .iter()
+                .copied()
+                .filter(|directory| {
+                    directory.matches('/').count() >= 3
+                        && !pinned
+                            .iter()
+                            .any(|path| path.starts_with(&format!("{directory}/")))
+                })
+                .collect();
+            if let Some(directory) = deep.first().map(|_| (*rng.pick(&deep)).to_string()) {
+                entries.push(Entry {
+                    path: format!("{directory}/.wh..wh..opq"),
+                    kind: Kind::Opaque,
+                });
+                let prefix = format!("{directory}/");
+                live.retain(|(path, _)| !path.starts_with(&prefix));
+                opaque_done = true;
+            }
+        }
+    }
+
+    // A body is shadowed if any later layer writes the same path, which is
+    // only known once every layer is planned.
+    let mut surviving: std::collections::BTreeMap<&str, u64> = std::collections::BTreeMap::new();
+    for entry in layers.iter().flatten() {
+        match &entry.kind {
+            Kind::File { size, .. } => {
+                surviving.insert(&entry.path, *size as u64);
+            }
+            _ => {
+                surviving.remove(entry.path.as_str());
+            }
+        }
+    }
+    counts.shadowed_bytes = counts.bytes - surviving.values().sum::<u64>();
+
+    (layers, counts)
+}
+
+/// A directory tree that is deep as well as wide, since resolving a path
+/// component by component is on the hot path.
+fn directories(rng: &mut Rng, count: usize) -> Vec<String> {
+    let mut directories: Vec<String> = vec![
+        "usr".into(),
+        "usr/lib".into(),
+        "usr/share".into(),
+        "usr/local".into(),
+        "etc".into(),
+        "opt".into(),
+        "opt/app".into(),
+        "var".into(),
+        "var/lib".into(),
+    ];
+    let seeds = directories.len();
+    while directories.len() < count.max(seeds) {
+        // Biased towards what was just created, which is what makes the tree
+        // deep rather than a flat fan out.
+        let span = directories.len().min(64);
+        let mut parent = directories[directories.len() - 1 - rng.below(span)].clone();
+        // Climbing rather than retrying: once the recent window is all at the
+        // depth limit, retrying never finds a parent and never terminates.
+        if parent.matches('/').count() >= 6 {
+            parent = parent.split('/').take(4).collect::<Vec<_>>().join("/");
+        }
+        let child = format!("{parent}/{}{}", rng.pick(&WORDS), directories.len());
+        directories.push(child);
+    }
+    directories.truncate(count.max(seeds));
+    directories
+}
+
+fn file_name(rng: &mut Rng) -> String {
+    format!(
+        "{}{}.{}",
+        rng.pick(&WORDS),
+        rng.next() % 1_000_000,
+        rng.pick(&EXTENSIONS)
+    )
+}
+
+fn whiteout_of(path: &str) -> String {
+    match path.rsplit_once('/') {
+        Some((directory, name)) => format!("{directory}/.wh.{name}"),
+        None => format!(".wh.{path}"),
+    }
+}
+
+/// Body sizes taken from the reference image: median 5.2 KiB, p90 54.6 KiB,
+/// p99 361 KiB, and the 0.36% over a megabyte holding two thirds of the
+/// bytes. Getting this wrong is how a benchmark ends up measuring per entry
+/// overhead when the real cost is throughput, or the reverse.
+///
+/// Log-uniform within each bucket, which is what puts the median where the
+/// percentile says rather than halfway up the range.
+fn body_size(rng: &mut Rng, scale: f64, tail: bool) -> usize {
+    let (low, high): (f64, f64) = match rng.unit() {
+        u if u < 0.50 => (256.0, 5_324.0),
+        u if u < 0.90 => (5_324.0, 55_910.0),
+        // A rewrite is a small file being patched, not a new blob: the
+        // reference shadows 418 MiB across 23,475 of them, some 18 KiB each.
+        u if u < 0.99 || !tail => (55_910.0, 369_664.0),
+        u if u < 0.9964 => (369_664.0, 1_100_000.0),
+        _ => (1_100_000.0, 77_600_000.0),
+    };
+    let size = low * (high / low).powf(rng.unit()) * scale;
+    size.max(1.0) as usize
+}
+
+/// Bodies compress like real ones. A layer of real files -- binaries, images,
+/// already compressed assets -- gives deflate around two and a half times, so
+/// the window here is part dictionary words and part high entropy filler.
+/// Plain words would compress five times and make the decompressor look far
+/// too good; random bytes would not compress at all and make it look bad.
+fn body(seed: u64, size: usize) -> Vec<u8> {
+    // One window, repeated. The repeat is 64 KiB apart, well outside
+    // deflate's 32 KiB window, so it cannot be matched away.
+    const WINDOW: usize = 64 << 10;
+    const ALPHABET: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/";
+    let mut rng = Rng::new(seed);
+    let mut window = Vec::with_capacity(WINDOW.min(size) + 64);
+    while window.len() < WINDOW.min(size) {
+        if rng.below(10) < 7 {
+            window.extend_from_slice(rng.pick(&WORDS).as_bytes());
+            window.push(if rng.below(8) == 0 { b'\n' } else { b' ' });
+        } else {
+            for _ in 0..8 {
+                window.push(ALPHABET[rng.below(ALPHABET.len())]);
+            }
+        }
+    }
+
+    let mut body = Vec::with_capacity(size);
+    let span = window.len();
+    while body.len() < size {
+        let take = (size - body.len()).min(span);
+        body.extend_from_slice(&window[..take]);
+        // Rotating keeps consecutive windows from matching each other.
+        window.rotate_left((1 + body.len() % 7) % span);
+    }
+    body.truncate(size);
+    body
+}
+
+struct LayerBlob {
+    digest: String,
+    diff_id: String,
+    size: u64,
+}
+
+fn compress(
+    layers: &[Vec<Entry>],
+    output: &Utf8Path,
+    workers: usize,
+) -> io::Result<Vec<LayerBlob>> {
+    let built: Mutex<Vec<Option<LayerBlob>>> =
+        Mutex::new((0..layers.len()).map(|_| None).collect());
+    let next = AtomicUsize::new(0);
+    let failure: Mutex<Option<io::Error>> = Mutex::new(None);
+
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| {
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    if index >= layers.len() {
+                        return;
+                    }
+                    match build_layer(&layers[index], output) {
+                        Ok(blob) => built.lock().expect("built")[index] = Some(blob),
+                        Err(err) => {
+                            *failure.lock().expect("failure") = Some(err);
+                            return;
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    if let Some(err) = failure.into_inner().expect("failure") {
+        return Err(err);
+    }
+    Ok(built
+        .into_inner()
+        .expect("built")
+        .into_iter()
+        .map(|blob| blob.expect("every layer built"))
+        .collect())
+}
+
+fn build_layer(entries: &[Entry], output: &Utf8Path) -> io::Result<LayerBlob> {
+    // Straight to disk rather than into a buffer: the base layer of the full
+    // profile is a few hundred megabytes on its own, and several workers hold
+    // one each.
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    let blobs = output.join("blobs/sha256");
+    let staging = blobs.join(format!("partial.{}", NEXT.fetch_add(1, Ordering::Relaxed)));
+
+    let file = io::BufWriter::new(fs::File::create(&staging)?);
+    let encoder = GzBuilder::new()
+        .mtime(0)
+        .write(Hashing::new(file), Compression::new(6));
+    let mut builder = tar::Builder::new(Hashing::new(encoder));
+    for entry in entries {
+        append(&mut builder, entry)?;
+    }
+
+    let plain = builder.into_inner()?;
+    let (encoder, diff_id, _) = plain.finish();
+    let mut packed = encoder.finish()?;
+    io::Write::flush(&mut packed)?;
+    let (mut file, digest, size) = packed.finish();
+    io::Write::flush(&mut file)?;
+
+    fs::rename(&staging, blobs.join(&digest))?;
+    Ok(LayerBlob {
+        digest: format!("sha256:{digest}"),
+        diff_id: format!("sha256:{diff_id}"),
+        size,
+    })
+}
+
+/// Hashes and counts everything on its way through.
+struct Hashing<W> {
+    inner: W,
+    hasher: Sha256,
+    written: u64,
+}
+
+impl<W: io::Write> Hashing<W> {
+    fn new(inner: W) -> Self {
+        Hashing {
+            inner,
+            hasher: Sha256::new(),
+            written: 0,
+        }
+    }
+
+    fn finish(self) -> (W, String, u64) {
+        (
+            self.inner,
+            hex_encode(&self.hasher.finalize()),
+            self.written,
+        )
+    }
+}
+
+impl<W: io::Write> io::Write for Hashing<W> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buffer)?;
+        self.hasher.update(&buffer[..written]);
+        self.written += written as u64;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn append<W: io::Write>(builder: &mut tar::Builder<W>, entry: &Entry) -> io::Result<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_mtime(MTIME);
+    header.set_uid(0);
+    header.set_gid(0);
+    match &entry.kind {
+        Kind::Directory => {
+            header.set_entry_type(tar::EntryType::Directory);
+            header.set_mode(0o755);
+            header.set_size(0);
+            builder.append_data(&mut header, format!("{}/", entry.path), io::empty())
+        }
+        Kind::File { size, mode, seed } => {
+            header.set_mode(*mode);
+            header.set_size(*size as u64);
+            builder.append_data(&mut header, &entry.path, &body(*seed, *size)[..])
+        }
+        Kind::Symlink { target } => {
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_mode(0o777);
+            header.set_size(0);
+            builder.append_link(&mut header, &entry.path, target.as_str())
+        }
+        Kind::HardLink { target } => {
+            header.set_entry_type(tar::EntryType::Link);
+            header.set_mode(0o644);
+            header.set_size(0);
+            builder.append_link(&mut header, &entry.path, target.as_str())
+        }
+        Kind::Whiteout | Kind::Opaque => {
+            header.set_mode(0o644);
+            header.set_size(0);
+            builder.append_data(&mut header, &entry.path, io::empty())
+        }
+    }
+}
+
+fn write_blob(output: &Utf8Path, bytes: &[u8]) -> io::Result<(String, u64)> {
+    let hex = hex_encode(&Sha256::digest(bytes));
+    let path = output.join("blobs/sha256").join(&hex);
+    if !path.exists() {
+        // A temporary neighbour keeps two workers from seeing a half written
+        // blob, which is possible when two layers happen to be identical.
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+        let staging =
+            path.with_extension(format!("partial.{}", NEXT.fetch_add(1, Ordering::Relaxed)));
+        fs::write(&staging, bytes)?;
+        fs::rename(&staging, &path)?;
+    }
+    Ok((format!("sha256:{hex}"), bytes.len() as u64))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn human(bytes: u64) -> String {
+    match bytes {
+        bytes if bytes >= 1 << 20 => format!("{:.1} MiB", bytes as f64 / (1u64 << 20) as f64),
+        bytes if bytes >= 1 << 10 => format!("{:.1} KiB", bytes as f64 / (1u64 << 10) as f64),
+        bytes => format!("{bytes} B"),
+    }
+}
+
+fn host_architecture() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    }
+}

--- a/source/src/bin/bench_run.rs
+++ b/source/src/bin/bench_run.rs
@@ -1,0 +1,622 @@
+//! Runs launcher binaries against the same image and reports what separates
+//! them.
+//!
+//! The hard part of benchmarking this launcher has never been taking a
+//! measurement, it has been believing one. Wall clock on this workload moves
+//! several percent between reboots, an A/B of two binaries in a fixed order
+//! once invented a 4.6% regression that four binaries and a reversed order
+//! made disappear, and a stale sidecar directory silently sent two rounds down
+//! the walk while they were being attributed to the span route.
+//!
+//! So this harness:
+//!
+//! - builds each binary's sidecars with that binary, and reports the route
+//!   every binary actually took, refusing to compare two that disagree;
+//! - discards a warmup run, interleaves the rest round robin, and reverses the
+//!   order every other round;
+//! - reports counts as well as times -- entries placed, syscalls made, faults
+//!   taken -- because a count does not care what else the host was doing;
+//! - says "within noise" rather than printing a number that cannot be
+//!   attributed.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use clap::{Parser, ValueEnum};
+
+/// Below this, a wall clock or CPU difference on this workload is the host,
+/// not the change. Measured by running the same binary against itself.
+const NOISE_FLOOR: f64 = 0.02;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "bench_run",
+    about = "Compare launcher binaries on one image, interleaved"
+)]
+struct Args {
+    /// Image layout to extract, as `bench_image` writes one.
+    #[arg(long, value_name = "DIR")]
+    layout: Utf8PathBuf,
+
+    /// Timed rounds. Each round runs every binary once.
+    #[arg(long, default_value_t = 5)]
+    rounds: usize,
+
+    /// Which extraction route to put under test.
+    #[arg(long, value_enum, default_value_t = Mode::Indexed)]
+    mode: Mode,
+
+    /// Scratch space for sidecars and extracted trees. Emptied as it goes.
+    #[arg(long, value_name = "DIR", default_value = "/tmp/bench-run")]
+    work: Utf8PathBuf,
+
+    /// Also count syscalls under `strace`, in a pass of its own.
+    #[arg(long)]
+    syscalls: bool,
+
+    /// Also count instructions under `perf stat`, if the host allows it.
+    #[arg(long)]
+    perf: bool,
+
+    /// Refuse an image whose layers set extended attributes. Generated
+    /// fixtures set none; pulled images usually do.
+    #[arg(long, value_name = "BOOL", action = clap::ArgAction::Set, default_value_t = false)]
+    strict_xattrs: bool,
+
+    /// Launcher binaries to compare. The first is the baseline everything else
+    /// is reported against. Passing the same binary twice is the way to see
+    /// what this host's noise floor really is.
+    #[arg(required = true, value_name = "BINARY")]
+    binaries: Vec<Utf8PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Mode {
+    /// With sidecars, which is what a Bazel built image gets.
+    Indexed,
+    /// Without them, which is the fallback route.
+    Streaming,
+}
+
+/// One binary under test, and where its sidecars live.
+struct Subject {
+    label: String,
+    binary: Utf8PathBuf,
+    indexes: Option<Utf8PathBuf>,
+    route: String,
+}
+
+/// What one run cost. Times come from `wait4`, so they are the child's own and
+/// not this process's.
+#[derive(Default, Clone)]
+struct Sample {
+    wall: Duration,
+    cpu: Duration,
+    /// Peak resident set. Very noisy here: the blobs are mapped, so residency
+    /// follows page cache pressure rather than the launcher's own appetite.
+    maxrss: u64,
+    minor_faults: u64,
+    major_faults: u64,
+    context_switches: u64,
+    /// Entries left in the extracted tree, which is how a run that quietly did
+    /// less work is caught.
+    entries: u64,
+}
+
+fn main() {
+    let args = Args::parse();
+    if let Err(err) = run(&args) {
+        eprintln!("bench_run: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn run(args: &Args) -> io::Result<()> {
+    if args.work.exists() {
+        fs::remove_dir_all(&args.work)?;
+    }
+    fs::create_dir_all(&args.work)?;
+
+    let subjects = prepare(args)?;
+    let routes: Vec<&str> = subjects.iter().map(|s| s.route.as_str()).collect();
+    if routes.windows(2).any(|pair| pair[0] != pair[1]) {
+        eprintln!("bench_run: the binaries took different routes, so this compares nothing:");
+        for subject in &subjects {
+            eprintln!("  {:<20} {}", subject.label, subject.route);
+        }
+        std::process::exit(1);
+    }
+    println!(
+        "{} on {}, {} route, {} rounds\n",
+        args.layout,
+        args.mode_name(),
+        subjects[0].route,
+        args.rounds
+    );
+    let paths: std::collections::BTreeSet<&Utf8PathBuf> = args.binaries.iter().collect();
+    if paths.len() < args.binaries.len() {
+        println!("A binary appears twice: every difference below is this host's floor.\n");
+    }
+
+    let mut samples: BTreeMap<String, Vec<Sample>> = BTreeMap::new();
+    for round in 0..args.rounds {
+        // Reversed every other round. A fixed order is how a difference that
+        // is really cache state gets attributed to the second binary.
+        let order: Vec<&Subject> = if round % 2 == 0 {
+            subjects.iter().collect()
+        } else {
+            subjects.iter().rev().collect()
+        };
+        for subject in order {
+            let sample = measure(args, subject)?;
+            samples
+                .entry(subject.label.clone())
+                .or_default()
+                .push(sample);
+        }
+    }
+
+    report(&subjects, &samples);
+
+    if args.syscalls {
+        syscalls(args, &subjects)?;
+    }
+    if args.perf {
+        perf(args, &subjects)?;
+    }
+
+    fs::remove_dir_all(&args.work)?;
+    // Sidecars and trees are gone, so nothing here can be reused by a later
+    // run without being rebuilt, which is the point.
+    Ok(())
+}
+
+impl Args {
+    fn mode_name(&self) -> &'static str {
+        match self.mode {
+            Mode::Indexed => "indexed",
+            Mode::Streaming => "streaming",
+        }
+    }
+
+    fn run_dir(&self) -> Utf8PathBuf {
+        self.work.join("run")
+    }
+}
+
+/// Builds each binary's own sidecars and finds out what route it takes, then
+/// throws away a run to get the page cache into the state the timed runs will
+/// see.
+fn prepare(args: &Args) -> io::Result<Vec<Subject>> {
+    let mut subjects = Vec::new();
+    for (nth, binary) in args.binaries.iter().enumerate() {
+        let name = binary.file_name().unwrap_or("binary");
+        let label = format!("{}:{name}", nth + 1);
+
+        let indexes = match args.mode {
+            Mode::Streaming => None,
+            Mode::Indexed => {
+                // Its own, never a directory left over from another build:
+                // an entry table this binary cannot read resolves no plan and
+                // silently drops it onto the walk.
+                let indexes = args.work.join(format!("idx-{}", nth + 1));
+                let status = Command::new(binary)
+                    .args(["index", "--layout"])
+                    .arg(&args.layout)
+                    .arg("--output")
+                    .arg(&indexes)
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()?;
+                if !status.success() {
+                    return Err(io::Error::other(format!(
+                        "{binary} could not index the layout"
+                    )));
+                }
+                Some(indexes)
+            }
+        };
+
+        let mut subject = Subject {
+            label,
+            binary: binary.clone(),
+            indexes,
+            route: String::new(),
+        };
+        subject.route = route_of(args, &subject)?;
+        subjects.push(subject);
+    }
+    Ok(subjects)
+}
+
+/// The warmup run, kept for what it says about itself. `--verbose` costs a
+/// little, so its timings are thrown away.
+fn route_of(args: &Args, subject: &Subject) -> io::Result<String> {
+    let run = args.run_dir();
+    reset(&run)?;
+    let output = launcher(args, subject, &run)
+        .arg("--verbose")
+        // `output` leaves a stream alone once it has been set, and the
+        // launcher's own report is the only way to know which route ran.
+        .stderr(Stdio::piped())
+        .output()?;
+    let log = String::from_utf8_lossy(&output.stderr);
+    let route = if log.contains("units on") {
+        let units = log
+            .lines()
+            .find(|line| line.contains("units on"))
+            .unwrap_or_default()
+            .trim();
+        format!("spans ({units})")
+    } else if log.contains("Extracting layer") {
+        let checkpoints = log
+            .lines()
+            .filter(|line| line.contains("using") && line.contains("checkpoints"))
+            .count();
+        format!("walk ({checkpoints} of {} layers resumed)", layers(&log))
+    } else {
+        return Err(io::Error::other(format!(
+            "{} extracted nothing:\n{}",
+            subject.binary,
+            log.lines().rev().take(3).collect::<Vec<_>>().join("\n")
+        )));
+    };
+    let _ = fs::remove_dir_all(&run);
+    Ok(route)
+}
+
+fn layers(log: &str) -> usize {
+    log.lines()
+        .filter(|line| line.starts_with("Extracting layer"))
+        .count()
+}
+
+fn launcher(args: &Args, subject: &Subject, run: &Utf8Path) -> Command {
+    let mut command = Command::new(&subject.binary);
+    command
+        .args(["run", "--layout"])
+        .arg(&args.layout)
+        // Extraction is what is being measured, so the container is never
+        // started: the bundle is built and left where it can be counted.
+        .args(["--runtime", "/nonexistent/runc", "--keep-bundle"])
+        .arg(format!("--strict-xattrs={}", args.strict_xattrs))
+        .env("TMPDIR", run)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(indexes) = &subject.indexes {
+        command.arg("--index").arg(indexes);
+    }
+    command
+}
+
+fn measure(args: &Args, subject: &Subject) -> io::Result<Sample> {
+    let run = args.run_dir();
+    reset(&run)?;
+
+    let mut command = launcher(args, subject, &run);
+    let start = Instant::now();
+    let child = command.spawn()?;
+    let mut status = 0;
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+    // Reaping by hand rather than through `Child::wait`, which throws the
+    // resource usage away.
+    loop {
+        // SAFETY: both out pointers are ours and live across the call.
+        let reaped = unsafe { libc::wait4(child.id() as libc::pid_t, &mut status, 0, &mut usage) };
+        if reaped >= 0 {
+            break;
+        }
+        if io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    let wall = start.elapsed();
+
+    let entries = count_entries(&run)?;
+    let sample = Sample {
+        wall,
+        cpu: timeval(usage.ru_utime) + timeval(usage.ru_stime),
+        maxrss: usage.ru_maxrss as u64,
+        minor_faults: usage.ru_minflt as u64,
+        major_faults: usage.ru_majflt as u64,
+        context_switches: (usage.ru_nvcsw + usage.ru_nivcsw) as u64,
+        entries,
+    };
+    let _ = fs::remove_dir_all(&run);
+    Ok(sample)
+}
+
+fn timeval(time: libc::timeval) -> Duration {
+    Duration::new(time.tv_sec as u64, time.tv_usec as u32 * 1_000)
+}
+
+fn reset(run: &Utf8Path) -> io::Result<()> {
+    if run.exists() {
+        fs::remove_dir_all(run)?;
+    }
+    fs::create_dir_all(run)
+}
+
+/// Everything the run left behind, symlinks included and never followed.
+fn count_entries(root: &Utf8Path) -> io::Result<u64> {
+    let mut count = 0;
+    let mut stack = vec![root.as_std_path().to_path_buf()];
+    while let Some(directory) = stack.pop() {
+        for entry in fs::read_dir(&directory)? {
+            let entry = entry?;
+            count += 1;
+            if entry.file_type()?.is_dir() {
+                stack.push(entry.path());
+            }
+        }
+    }
+    Ok(count)
+}
+
+fn report(subjects: &[Subject], samples: &BTreeMap<String, Vec<Sample>>) {
+    let entries: Vec<u64> = samples
+        .values()
+        .flatten()
+        .map(|sample| sample.entries)
+        .collect();
+    let agreed: std::collections::BTreeSet<u64> = entries.iter().copied().collect();
+    if agreed.len() == 1 {
+        println!("entries  {} in every run\n", entries[0]);
+    } else {
+        println!("entries  DISAGREE {agreed:?} -- a run that placed fewer entries did less work\n");
+    }
+
+    let metrics: [(&str, fn(&Sample) -> f64, bool); 6] = [
+        ("wall s", |s| s.wall.as_secs_f64(), true),
+        ("cpu s", |s| s.cpu.as_secs_f64(), true),
+        ("maxrss MiB", |s| s.maxrss as f64 / 1024.0, true),
+        ("minor faults", |s| s.minor_faults as f64, false),
+        ("major faults", |s| s.major_faults as f64, false),
+        ("ctx switches", |s| s.context_switches as f64, false),
+    ];
+
+    let baseline = &subjects[0].label;
+    println!(
+        "{:<14} {:>10} {:>10} {:>10} {:>8}   {}",
+        "metric", "min", "median", "max", "spread", "vs baseline (min)"
+    );
+    for (name, of, timed) in metrics {
+        let base = summarise(&samples[baseline].iter().map(of).collect::<Vec<_>>());
+        // What the baseline alone did across its own rounds. A difference
+        // smaller than that is not a difference: the same binary produced it
+        // twice over.
+        let floor = NOISE_FLOOR.max(spread(base));
+        for subject in subjects {
+            let values: Vec<f64> = samples[&subject.label].iter().map(of).collect();
+            let (min, median, max) = summarise(&values);
+            let against = if &subject.label == baseline {
+                "baseline".to_string()
+            } else {
+                delta(base.0, min, timed.then_some(floor))
+            };
+            println!(
+                "{:<14} {:>10.3} {:>10.3} {:>10.3} {:>7.1}%   {:<12} {}",
+                name,
+                min,
+                median,
+                max,
+                spread((min, median, max)) * 100.0,
+                subject.label,
+                against
+            );
+        }
+        println!();
+    }
+    println!(
+        "Spread is one binary against itself. A time within it, or within {:.0}%, is the host.",
+        NOISE_FLOOR * 100.0
+    );
+}
+
+fn summarise(values: &[f64]) -> (f64, f64, f64) {
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let median = sorted[sorted.len() / 2];
+    (sorted[0], median, sorted[sorted.len() - 1])
+}
+
+/// How far one binary's own rounds ranged, as a fraction of its best.
+fn spread((min, _, max): (f64, f64, f64)) -> f64 {
+    if min == 0.0 { 0.0 } else { (max - min) / min }
+}
+
+fn delta(baseline: f64, value: f64, floor: Option<f64>) -> String {
+    if baseline == 0.0 {
+        return String::new();
+    }
+    let change = (value - baseline) / baseline;
+    let text = format!("{:+.1}%", change * 100.0);
+    match floor {
+        Some(floor) if change.abs() < floor => format!("{text} (within noise)"),
+        _ => text,
+    }
+}
+
+/// Syscall counts, in a pass of their own: `strace` intercepts every one of
+/// them, so a run under it is several times slower and its timings are worth
+/// nothing. What the counts are worth is that they do not move when the host
+/// is busy, so a difference of one is a difference.
+fn syscalls(args: &Args, subjects: &[Subject]) -> io::Result<()> {
+    if Command::new("strace")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_err()
+    {
+        println!("\nstrace is not installed, so no syscall counts.");
+        return Ok(());
+    }
+
+    println!("\nsyscalls (counts, not timings -- strace makes the run several times slower)");
+    let mut counted: Vec<(String, BTreeMap<String, u64>, u64)> = Vec::new();
+    for subject in subjects {
+        let run = args.run_dir();
+        reset(&run)?;
+        let out = args.work.join("strace.out");
+        let mut command = Command::new("strace");
+        command
+            .args(["-f", "-c", "-U", "name,calls", "-o"])
+            .arg(&out)
+            .arg(&subject.binary)
+            .args(["run", "--layout"])
+            .arg(&args.layout)
+            .args(["--runtime", "/nonexistent/runc", "--keep-bundle"])
+            .arg(format!("--strict-xattrs={}", args.strict_xattrs))
+            .env("TMPDIR", &run)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        if let Some(indexes) = &subject.indexes {
+            command.arg("--index").arg(indexes);
+        }
+        command.status()?;
+        let counts = parse_strace(&fs::read_to_string(&out)?);
+        counted.push((subject.label.clone(), counts, count_entries(&run)?));
+        let _ = fs::remove_dir_all(&run);
+    }
+
+    let baseline = &counted[0].1;
+    let mut names: Vec<&String> = counted.iter().flat_map(|(_, c, _)| c.keys()).collect();
+    names.sort_unstable();
+    names.dedup();
+
+    print!("{:<20}", "syscall");
+    for (label, _, _) in &counted {
+        print!("{label:>16}");
+    }
+    println!();
+    print!("{:<20}", "total");
+    for (_, counts, _) in &counted {
+        print!("{:>16}", counts.values().sum::<u64>());
+    }
+    println!();
+    print!("{:<20}", "entries placed");
+    for (_, _, entries) in &counted {
+        print!("{entries:>16}");
+    }
+    println!();
+
+    let mut moved = 0;
+    for name in names {
+        let counts: Vec<u64> = counted
+            .iter()
+            .map(|(_, c, _)| c.get(name).copied().unwrap_or(0))
+            .collect();
+        if counts.iter().all(|count| *count == counts[0]) {
+            continue;
+        }
+        moved += 1;
+        // Only what moved, and only what is worth reading: futex and friends
+        // count how the threads happened to interleave, not what was asked of
+        // the kernel.
+        let noisy = matches!(
+            name.as_str(),
+            "futex" | "sched_yield" | "epoll_wait" | "restart_syscall" | "clock_nanosleep"
+        );
+        print!(
+            "{:<20}",
+            if noisy {
+                format!("{name} (noisy)")
+            } else {
+                name.clone()
+            }
+        );
+        for count in &counts {
+            print!("{count:>16}");
+        }
+        let base = baseline.get(name).copied().unwrap_or(0);
+        println!(
+            "   {}",
+            delta(base as f64, counts[counts.len() - 1] as f64, None)
+        );
+    }
+    if moved == 0 {
+        println!(
+            "every syscall count identical -- nothing here changed what was asked of the kernel"
+        );
+    }
+    Ok(())
+}
+
+/// `strace -c -U name,calls` reports two columns and nothing else. The
+/// default report leaves the errors column blank for most syscalls, so its
+/// fields cannot be told apart by position.
+fn parse_strace(report: &str) -> BTreeMap<String, u64> {
+    let mut counts = BTreeMap::new();
+    for line in report.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() != 2 || fields[0] == "total" {
+            continue;
+        }
+        if let Ok(count) = fields[1].parse::<u64>() {
+            *counts.entry(fields[0].to_string()).or_insert(0) += count;
+        }
+    }
+    counts
+}
+
+/// Instructions retired is the metric that survives a busy host: it counts
+/// what the CPU was asked to do rather than how long it took to do it.
+/// Containers and VMs often will not allow it, so this is best effort.
+fn perf(args: &Args, subjects: &[Subject]) -> io::Result<()> {
+    let probe = Command::new("perf")
+        .args(["stat", "-e", "instructions", "true"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output();
+    let allowed = matches!(&probe, Ok(output) if output.status.success());
+    if !allowed {
+        let why = match &probe {
+            Ok(output) => String::from_utf8_lossy(&output.stderr)
+                .lines()
+                .find(|line| line.contains("not permitted") || line.contains("access"))
+                .unwrap_or("perf stat failed")
+                .trim()
+                .to_string(),
+            Err(err) => err.to_string(),
+        };
+        println!("\nno hardware counters: {why}");
+        return Ok(());
+    }
+
+    println!("\nperf (instructions and cycles retired, one run each)");
+    for subject in subjects {
+        let run = args.run_dir();
+        reset(&run)?;
+        let out = args.work.join("perf.out");
+        let mut command = Command::new("perf");
+        command
+            .args(["stat", "-x,", "-e", "instructions,cycles,page-faults", "-o"])
+            .arg(&out)
+            .arg("--")
+            .arg(&subject.binary)
+            .args(["run", "--layout"])
+            .arg(&args.layout)
+            .args(["--runtime", "/nonexistent/runc", "--keep-bundle"])
+            .arg(format!("--strict-xattrs={}", args.strict_xattrs))
+            .env("TMPDIR", &run)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        if let Some(indexes) = &subject.indexes {
+            command.arg("--index").arg(indexes);
+        }
+        command.status()?;
+        for line in fs::read_to_string(&out)?.lines() {
+            let fields: Vec<&str> = line.split(',').collect();
+            if fields.len() > 2 && fields[0].parse::<f64>().is_ok() {
+                println!("{:<14} {:>18} {}", subject.label, fields[0], fields[2]);
+            }
+        }
+        let _ = fs::remove_dir_all(&run);
+    }
+    Ok(())
+}

--- a/source/tests/counts.rs
+++ b/source/tests/counts.rs
@@ -1,0 +1,383 @@
+//! What the launcher asks of the kernel, and what it leaves on disk, held to
+//! exact numbers.
+//!
+//! Time is not asserted anywhere here. A CI runner's wall clock moves by more
+//! than any change worth catching, and this repository has already attributed
+//! a 4.6% "regression" to a binary that turned out to be innocent. Counts do
+//! not move: a syscall is made or it is not, an entry is placed or it is not,
+//! and a body the plan skipped is a body that was never read. So a change that
+//! adds a `stat` per entry, or stops skipping a shadowed body, fails here even
+//! though nothing measurable happened to the clock.
+//!
+//! The numbers come from `bench_image --profile small`, whose whole
+//! reproduction is its seed. When the generator changes they change with it:
+//! run this test, read the numbers it reports, and update them here.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+/// Entries under `rootfs`, not counting the three files the launcher writes
+/// itself.
+const ENTRIES: usize = 172;
+
+/// What the plan works out before a single body is written.
+const SKIPPED_FILES: usize = 165;
+const PLANNED_DIRECTORIES: usize = 56;
+const SPAN_UNITS: usize = 12;
+
+/// Syscalls neither libc nor the host can account for: every one of these is
+/// the extractor placing something. Grouped into families because the
+/// architecture decides which member libc reaches for -- arm64 has no `mkdir`
+/// syscall at all, only `mkdirat`.
+const WALK_SYSCALLS: [(&str, u64); 7] = [
+    ("mkdir", 61),
+    ("symlink", 11),
+    ("link", 2),
+    ("unlink", 244),
+    ("chmod", 60),
+    ("fchmod", 347),
+    ("utimensat", 358),
+];
+
+/// The span route places the same tree, and the difference is the point of it:
+/// it opens and writes only the bodies that survive, and it never has to
+/// unlink what a later layer replaces because it never wrote it.
+const SPAN_SYSCALLS: [(&str, u64); 7] = [
+    ("mkdir", 61),
+    ("symlink", 11),
+    ("link", 2),
+    ("unlink", 0),
+    ("chmod", 60),
+    ("fchmod", 103),
+    ("utimensat", 114),
+];
+
+const FAMILIES: [(&str, &[&str]); 7] = [
+    ("mkdir", &["mkdir", "mkdirat"]),
+    ("symlink", &["symlink", "symlinkat"]),
+    ("link", &["link", "linkat"]),
+    ("unlink", &["unlink", "unlinkat"]),
+    ("chmod", &["chmod", "fchmodat", "fchmodat2"]),
+    ("fchmod", &["fchmod"]),
+    (
+        "utimensat",
+        &["utimensat", "utimensat_time64", "utime", "utimes"],
+    ),
+];
+
+/// The launcher writes these into the rootfs itself, so they say nothing about
+/// the image.
+const LAUNCHER_WRITES: [&str; 3] = ["etc/hosts", "etc/hostname", "etc/resolv.conf"];
+
+fn scratch() -> &'static Path {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        let root = match std::env::var("TEST_TMPDIR") {
+            Ok(dir) => PathBuf::from(dir),
+            Err(_) => std::env::temp_dir(),
+        }
+        .join("bench-counts");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("scratch");
+        root
+    })
+}
+
+/// Bazel passes the paths it built; cargo names them at compile time.
+fn tool(variable: &str, built: Option<&'static str>) -> PathBuf {
+    match std::env::var(variable) {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => PathBuf::from(built.unwrap_or_else(|| {
+            panic!("neither ${variable} nor a cargo built binary to fall back on")
+        })),
+    }
+}
+
+fn bench_image() -> PathBuf {
+    tool("BENCH_IMAGE", option_env!("CARGO_BIN_EXE_bench_image"))
+}
+
+fn oci_runtime() -> PathBuf {
+    tool("OCI_RUNTIME", option_env!("CARGO_BIN_EXE_oci_runtime"))
+}
+
+/// The fixture and its sidecars, built once for every test in this file.
+fn fixture() -> &'static (PathBuf, PathBuf) {
+    static FIXTURE: OnceLock<(PathBuf, PathBuf)> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let layout = scratch().join("layout");
+        generate(&layout);
+        let indexes = scratch().join("indexes");
+        let status = Command::new(oci_runtime())
+            .arg("index")
+            .arg("--layout")
+            .arg(&layout)
+            .arg("--output")
+            .arg(&indexes)
+            .status()
+            .expect("index");
+        assert!(status.success(), "the layout could not be indexed");
+        (layout, indexes)
+    })
+}
+
+fn generate(output: &Path) {
+    let result = Command::new(bench_image())
+        .arg("--output")
+        .arg(output)
+        .args(["--profile", "small"])
+        .output()
+        .expect("bench_image");
+    assert!(
+        result.status.success(),
+        "bench_image failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+/// The seed is the whole reproduction, so two runs must agree down to the
+/// blob digests. Without this every other number here is only as stable as
+/// the last person's machine.
+#[test]
+fn the_same_seed_builds_the_same_image() {
+    let first = scratch().join("repeat-a");
+    let second = scratch().join("repeat-b");
+    generate(&first);
+    generate(&second);
+    assert_eq!(
+        snapshot(&first),
+        snapshot(&second),
+        "the generator is not reproducible"
+    );
+}
+
+/// The routes are held to each other elsewhere; what is asserted here is that
+/// they place a known number of entries, so a run that quietly did less work
+/// cannot pass as a fast one.
+#[test]
+fn every_route_places_the_same_entries() {
+    let (layout, indexes) = fixture();
+    let walked = extract("walk", layout, None);
+    let spanned = extract("spans", layout, Some(indexes.as_path()));
+
+    assert_eq!(
+        entries(&walked.rootfs),
+        ENTRIES,
+        "the walk placed a different number of entries"
+    );
+    assert_eq!(
+        entries(&spanned.rootfs),
+        ENTRIES,
+        "the span route placed a different number of entries"
+    );
+    assert_eq!(
+        snapshot(&walked.rootfs),
+        snapshot(&spanned.rootfs),
+        "the two routes placed different trees"
+    );
+}
+
+/// The plan's own arithmetic, before anything is written. A change that stops
+/// the plan resolving shows up here as a route rather than as a slower run
+/// nobody can attribute.
+#[test]
+fn the_plan_skips_what_later_layers_replace() {
+    let (layout, indexes) = fixture();
+    let spanned = extract("plan", layout, Some(indexes.as_path()));
+
+    let skipped = number_before(&spanned.log, "files (", "Skipping ");
+    assert_eq!(skipped, Some(SKIPPED_FILES), "{}", spanned.log);
+    let created = number_before(&spanned.log, "directories", "Created ");
+    assert_eq!(created, Some(PLANNED_DIRECTORIES), "{}", spanned.log);
+    // Worker count follows the host's core count, so only the units are ours.
+    let units = number_before(&spanned.log, "units on", "as ");
+    assert_eq!(units, Some(SPAN_UNITS), "{}", spanned.log);
+}
+
+/// The metric that does not care what else the host was doing.
+#[test]
+fn neither_route_asks_the_kernel_for_more_than_it_needs() {
+    let Some(_) = which("strace") else {
+        eprintln!("strace is not installed, so syscall counts are not checked");
+        return;
+    };
+    let (layout, indexes) = fixture();
+
+    for (name, expected, index) in [
+        ("walk", WALK_SYSCALLS, None),
+        ("spans", SPAN_SYSCALLS, Some(indexes.as_path())),
+    ] {
+        let counts = traced(name, layout, index);
+        // A sandbox that refuses `ptrace` leaves nothing to compare, and a
+        // test that then asserts zeroes reports a regression that is really a
+        // missing permission.
+        if counts.is_empty() {
+            eprintln!("strace counted nothing, so syscall counts are not checked");
+            return;
+        }
+        let mut wrong = Vec::new();
+        for (family, want) in expected {
+            let members = FAMILIES
+                .iter()
+                .find(|(named, _)| *named == family)
+                .expect("a named family")
+                .1;
+            let got: u64 = members
+                .iter()
+                .map(|member| counts.get(*member).copied().unwrap_or(0))
+                .sum();
+            if got != want {
+                wrong.push(format!("{family}: expected {want}, counted {got}"));
+            }
+        }
+        assert!(wrong.is_empty(), "{name} route:\n  {}", wrong.join("\n  "));
+    }
+}
+
+struct Extraction {
+    rootfs: PathBuf,
+    log: String,
+}
+
+fn extract(name: &str, layout: &Path, indexes: Option<&Path>) -> Extraction {
+    let run = scratch().join(name);
+    let _ = fs::remove_dir_all(&run);
+    fs::create_dir_all(&run).expect("run directory");
+
+    let mut command = Command::new(oci_runtime());
+    command
+        .arg("run")
+        .arg("--layout")
+        .arg(layout)
+        .args(["--runtime", "/nonexistent/runc"])
+        .args(["--keep-bundle", "--verbose", "--strict-xattrs=false"])
+        .env("TMPDIR", &run);
+    if let Some(indexes) = indexes {
+        command.arg("--index").arg(indexes);
+    }
+    // The runtime is deliberately absent: the bundle is the whole subject, and
+    // starting a container needs privileges a test does not have.
+    let output = command.output().expect("oci_runtime");
+    let log = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    let bundle = fs::read_dir(&run)
+        .expect("bundle")
+        .next()
+        .expect("a bundle was left behind")
+        .expect("bundle entry")
+        .path();
+    Extraction {
+        rootfs: bundle.join("rootfs"),
+        log,
+    }
+}
+
+fn traced(name: &str, layout: &Path, indexes: Option<&Path>) -> BTreeMap<String, u64> {
+    let run = scratch().join(format!("traced-{name}"));
+    let _ = fs::remove_dir_all(&run);
+    fs::create_dir_all(&run).expect("run directory");
+    let report = scratch().join(format!("strace-{name}.out"));
+
+    let mut command = Command::new("strace");
+    command
+        .args(["-f", "-c", "-U", "name,calls", "-o"])
+        .arg(&report)
+        .arg(oci_runtime())
+        .arg("run")
+        .arg("--layout")
+        .arg(layout)
+        .args(["--runtime", "/nonexistent/runc"])
+        .args(["--keep-bundle", "--strict-xattrs=false"])
+        .env("TMPDIR", &run);
+    if let Some(indexes) = indexes {
+        command.arg("--index").arg(indexes);
+    }
+    command.output().expect("strace");
+
+    let mut counts = BTreeMap::new();
+    let Ok(report) = fs::read_to_string(&report) else {
+        return counts;
+    };
+    for line in report.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() != 2 || fields[0] == "total" {
+            continue;
+        }
+        if let Ok(count) = fields[1].parse::<u64>() {
+            counts.insert(fields[0].to_string(), count);
+        }
+    }
+    counts
+}
+
+/// Everything the image left, described well enough that two trees can be
+/// compared without reading their bodies twice.
+fn snapshot(root: &Path) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(directory) = stack.pop() {
+        let mut entries: Vec<PathBuf> = fs::read_dir(&directory)
+            .unwrap_or_else(|err| panic!("reading {}: {err}", directory.display()))
+            .map(|entry| entry.expect("entry").path())
+            .collect();
+        entries.sort();
+        for path in entries {
+            let relative = path.strip_prefix(root).expect("under the root");
+            let name = relative.to_string_lossy().into_owned();
+            if LAUNCHER_WRITES.contains(&name.as_str()) {
+                continue;
+            }
+            let meta = fs::symlink_metadata(&path).expect("metadata");
+            let kind = if meta.is_dir() {
+                stack.push(path.clone());
+                "d".to_string()
+            } else if meta.is_symlink() {
+                format!("l {}", fs::read_link(&path).expect("link").display())
+            } else {
+                // The body, not just its length: a route that wrote the wrong
+                // layer's copy leaves a file of the same size.
+                format!("f {:x}", fnv(&fs::read(&path).expect("body")))
+            };
+            lines.push(format!("{name} {:o} {} {kind}", meta.mode(), meta.nlink()));
+        }
+    }
+    lines.sort();
+    lines
+}
+
+/// FNV-1a. A comparison between two trees this test just built does not need
+/// anything stronger, and this file has no dependencies.
+fn fnv(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in bytes {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+fn entries(root: &Path) -> usize {
+    snapshot(root).len()
+}
+
+/// The number between `after` and `before` on the first line holding both.
+fn number_before(log: &str, before: &str, after: &str) -> Option<usize> {
+    let line = log
+        .lines()
+        .find(|line| line.contains(before) && line.contains(after))?;
+    let tail = &line[line.find(after)? + after.len()..];
+    let number: String = tail.chars().take_while(char::is_ascii_digit).collect();
+    number.parse().ok()
+}
+
+fn which(program: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH")?
+        .to_string_lossy()
+        .split(':')
+        .map(|dir| Path::new(dir).join(program))
+        .find(|path| path.is_file())
+}


### PR DESCRIPTION
Benchmarking is the recurring workstream here and every round of it has started by writing another throwaway script against an image that cannot be reproduced from this repository. The scripts disagreed with each other, the image did not survive a machine, and the numbers did not survive a reboot.

Three pieces, all in the source module, all built by Bazel and run outside it: a measurement taken through the sandbox is not the measurement anyone cares about.

`bench_image` writes a deterministic OCI layout; the seed is the whole reproduction. The `full` profile is shaped like the image the launcher is actually slow on rather than like a distribution base: 20 layers, 6,993 directories, 7,187 files, bodies log-uniform within the reference image's percentiles (median 5.2 KiB, p90 54.6 KiB, p99 361 KiB, 0.36% over a megabyte holding two thirds of the bytes), and 446 MiB of the 1,084 MiB shadowed by a later layer. It extracts as 20,008 files skipped (481 MiB) in 244 units, against chromium's 23,475 skipped (418 MiB) in 299 units. Both routes place it byte for byte identically.

`bench_run` compares binaries on one layout. It builds each binary's own sidecars and reports the route each took, refusing to compare two that disagree -- a stale index directory silently sent two rounds down the walk once and they were attributed to the span route. It discards a warmup, interleaves the rounds and reverses their order every other one, since an A/B of two binaries in a fixed order invented a 4.6% regression that four binaries and a reversed order made vanish. It reports each binary's spread against itself and calls a difference smaller than that noise.

Passing the same binary twice, 5 rounds on the full fixture:

```
wall  2.803 min, 4.8% spread   ->  -1.4% (within noise)
cpu   8.935 min, 11.3% spread  ->  -1.9% (within noise)
syscalls 68,236 total, futex the only one that moved
```

That last line is why `--syscalls` is here. Everything the launcher asks of the kernel outside its own thread pool is identical run to run, so a difference of one is a difference, whatever the host was doing.

`//:bench_counts_test` holds the same counts in CI, where the clock is worth nothing: 172 entries placed by both routes, 165 files skipped, 56 directories planned, 12 units, and the syscall families neither libc nor the architecture can account for -- 61 mkdir, 11 symlink, 2 link, 60 chmod, and 244 unlink on the walk against none on the span route, which never writes what a later layer replaces.

Traps met building it, in case the numbers ever need regenerating:

- A hard link whose target a later layer rewrites makes the whole image unplaceable, and the fixture silently fell back to the walk. Targets are pinned out of the rewrite and whiteout pools.
- Rewrites drawn from the same size distribution as fresh files shadowed 799 MiB of 988 and left a tree a third of the reference's. A rewrite is a small file changing, so it is capped.
- Bodies of dictionary words compress five times. Real layers give gzip about two and a half, so 30% of the window is high entropy filler.