### PR TITLE
perf: a worker keeps its decoder from span to span

### DIFF
--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -240,6 +240,7 @@ fn run(units: &[Unit], layers: &[Layer], work: &Work, plan: &Plan, root: &Path) 
             scope.spawn(move || {
                 let mut buffer = Vec::new();
                 let mut path = PathBuf::new();
+                let mut decoders = zinfo::Decoders::default();
                 while !stop.load(Ordering::Relaxed) {
                     let i = next.fetch_add(1, Ordering::Relaxed);
                     let Some(unit) = units.get(i) else { break };
@@ -257,6 +258,7 @@ fn run(units: &[Unit], layers: &[Layer], work: &Work, plan: &Plan, root: &Path) 
                             root,
                             &mut buffer,
                             &mut path,
+                            &mut decoders,
                         ),
                     };
                     if let Err(err) = result {
@@ -288,6 +290,7 @@ fn run_span(
     root: &Path,
     buffer: &mut Vec<u8>,
     path: &mut PathBuf,
+    decoders: &mut zinfo::Decoders,
 ) -> Result<()> {
     let base = layer.index.checkpoints[checkpoint].out_offset;
     let last = &table.entries[*entries.last().expect("a unit has entries") as usize];
@@ -310,7 +313,7 @@ fn run_span(
         }
         filled += layer
             .index
-            .extract_span_into(&layer.blob, at, buffer, filled)?;
+            .extract_span_into(&layer.blob, at, buffer, filled, decoders)?;
         at += 1;
     }
 

--- a/source/src/zinfo.rs
+++ b/source/src/zinfo.rs
@@ -241,7 +241,7 @@ impl Index {
     /// end of the stream) and verifies it against the recorded CRC.
     pub fn extract_span(&self, blob: &[u8], i: usize) -> Result<Vec<u8>> {
         let mut out = Vec::new();
-        self.extract_span_into(blob, i, &mut out, 0)?;
+        self.extract_span_into(blob, i, &mut out, 0, &mut Decoders::default())?;
         Ok(out)
     }
 
@@ -257,6 +257,7 @@ impl Index {
         i: usize,
         out: &mut Vec<u8>,
         at: usize,
+        decoders: &mut Decoders,
     ) -> Result<usize> {
         let context = "resuming from checkpoint";
         let point = &self.checkpoints[i];
@@ -281,8 +282,8 @@ impl Index {
         let span = &mut out[at..at + len];
         let mut crc = flate2::Crc::new();
         match self.flavor {
-            Flavor::Gzip => inflate_span(blob, point, span, &mut crc)?,
-            Flavor::Zstd => decode_span(blob, point, span, &mut crc)?,
+            Flavor::Gzip => inflate_span(blob, point, span, &mut crc, decoders)?,
+            Flavor::Zstd => decode_span(blob, point, span, &mut crc, decoders)?,
         }
 
         if crc.sum() != point.crc {
@@ -372,6 +373,36 @@ impl Index {
     }
 }
 
+/// Scratch that a span decode needs and the next one can have back.
+///
+/// Both decoders own buffers measured in tens of kilobytes to a megabyte, and
+/// a worker decodes span after span. Building them per span left the allocator
+/// asking the kernel for the same memory hundreds of times, and every unmap
+/// interrupts the other workers to shoot down their TLBs.
+#[derive(Default)]
+pub struct Decoders {
+    gzip: Option<Inflater>,
+    zstd: Option<(FrameDecoder, Vec<u8>)>,
+}
+
+impl Decoders {
+    /// An inflater rewound to `window_bits`, built on first use.
+    fn inflater(&mut self, window_bits: i32) -> io::Result<&mut Inflater> {
+        match &mut self.gzip {
+            Some(inflater) => inflater.reset_to(window_bits)?,
+            slot => *slot = Some(Inflater::new(window_bits)?),
+        }
+        Ok(self.gzip.as_mut().expect("just filled"))
+    }
+
+    fn zstd(&mut self) -> (&mut FrameDecoder, &mut Vec<u8>) {
+        let (decoder, scratch) = self
+            .zstd
+            .get_or_insert_with(|| (FrameDecoder::new(), vec![0u8; 1 << 20]));
+        (decoder, scratch)
+    }
+}
+
 /// Inflates one gzip span into `span`, which is exactly its length,
 /// checksumming each piece as it lands.
 fn inflate_span(
@@ -379,16 +410,18 @@ fn inflate_span(
     point: &Checkpoint,
     span: &mut [u8],
     crc: &mut flate2::Crc,
+    decoders: &mut Decoders,
 ) -> Result<()> {
     let context = "resuming from checkpoint";
     // An empty window is a stream or member start: parse the header there.
     let at_header = point.window.is_empty() && point.bits == 0;
-    let mut inflater = Inflater::new(if at_header {
-        HEADER_WINDOW_BITS
-    } else {
-        RAW_WINDOW_BITS
-    })
-    .map_err(|e| Error::io(context, e))?;
+    let inflater = decoders
+        .inflater(if at_header {
+            HEADER_WINDOW_BITS
+        } else {
+            RAW_WINDOW_BITS
+        })
+        .map_err(|e| Error::io(context, e))?;
     if point.bits != 0 {
         // The boundary sits inside the previous byte: feed its unconsumed
         // high bits, then continue from the byte boundary.
@@ -426,7 +459,9 @@ fn inflate_span(
                         io::Error::other("stream ended before the indexed span"),
                     ));
                 }
-                inflater = Inflater::new(HEADER_WINDOW_BITS).map_err(|e| Error::io(context, e))?;
+                inflater
+                    .reset_to(HEADER_WINDOW_BITS)
+                    .map_err(|e| Error::io(context, e))?;
             }
             Z_OK if consumed == 0 && produced == 0 => {
                 return Err(Error::io(
@@ -450,11 +485,11 @@ fn decode_span(
     point: &Checkpoint,
     span: &mut [u8],
     crc: &mut flate2::Crc,
+    decoders: &mut Decoders,
 ) -> Result<()> {
     let context = "resuming from checkpoint";
     let len = span.len();
-    let mut decoder = FrameDecoder::new();
-    let mut scratch = vec![0u8; 1 << 20];
+    let (decoder, scratch) = decoders.zstd();
     let mut pos = point.in_offset as usize;
     let mut filled = 0usize;
 
@@ -473,7 +508,7 @@ fn decode_span(
             continue;
         }
         let mut overflowed = false;
-        pos = decode_frame(&mut decoder, blob, pos, &mut scratch, |bytes| {
+        pos = decode_frame(decoder, blob, pos, scratch, |bytes| {
             let take = bytes.len().min(len - filled);
             span[filled..filled + take].copy_from_slice(&bytes[..take]);
             crc.update(&bytes[..take]);
@@ -667,6 +702,19 @@ impl Inflater {
         }
         Ok(())
     }
+
+    /// Rewinds to before the header and changes what header to expect, so one
+    /// inflater serves spans that resume at a member start and spans that
+    /// resume mid stream.
+    fn reset_to(&mut self, window_bits: i32) -> io::Result<()> {
+        // SAFETY: the stream is initialised; inflateReset2 accepts the same
+        // window bits inflateInit2_ does.
+        let ret = unsafe { libz_rs_sys::inflateReset2(&mut self.0, window_bits) };
+        if ret != Z_OK {
+            return Err(io::Error::other("inflateReset2 failed"));
+        }
+        Ok(())
+    }
 }
 
 impl Drop for Inflater {
@@ -755,7 +803,7 @@ mod tests {
         let mut buffer = vec![0xab; 4 << 20];
         let stale = buffer.len();
         let written = index
-            .extract_span_into(&blob, 1, &mut buffer, 0)
+            .extract_span_into(&blob, 1, &mut buffer, 0, &mut Decoders::default())
             .expect("span");
 
         let start = index.checkpoints[1].out_offset as usize;


### PR DESCRIPTION
Every span built its own decompressor and threw it away: gzip a 32 KiB window plus inflate state, zstd a `FrameDecoder` and a 1 MiB scratch buffer. A worker decodes span after span -- 287 checkpoints on the full fixture -- so the allocator asked the kernel for the same memory and gave it straight back, hundreds of times, while seven other threads ran. Every unmap of theirs is a TLB shootdown the others have to service.

`Decoders` is that scratch, built on first use and reset between spans: `inflateReset2` rewinds the inflater and switches it between expecting a gzip header and resuming raw, which is the only thing that differed between spans.

Measured on the full fixture:

```
gzip     mmap 1569 -> 1207, munmap 1563 -> 1201, futex 286 -> 15
         minor faults 96,328 -> 93,011   -3.4%
zstd     mmap 1403 -> 1010, munmap 1397 -> 1004
         minor faults 227,225 -> 196,142  -13.7%
```

zstd gains most because its per span scratch was a whole megabyte.

Instructions are flat (55,568.6M -> 55,567.3M): this is kernel work, not user work, and valgrind counts only the latter. Wall and cpu move less than this host's A/A spread in both directions, so they say nothing. The cost is holding the scratch: peak RSS +0.8% on zstd, eight workers each keeping a megabyte they used to borrow.