### PR TITLE
perf: the pipeline route works under the same worker cap

### DIFF
--- a/source/src/extract/pipeline.rs
+++ b/source/src/extract/pipeline.rs
@@ -196,9 +196,12 @@ pub(super) fn inflate_indexed(
     let blob: &[u8] = &blob;
 
     let spans = index.checkpoints.len();
+    // The same cap the span route works under, for the same reason: the two
+    // routes ask the memory system for the same thing.
     let workers = thread::available_parallelism()
         .map_or(1, |n| n.get())
-        .min(spans);
+        .min(spans)
+        .min(super::spans::MAX_WORKERS);
     let next = AtomicUsize::new(0);
     let stop = AtomicBool::new(false);
 
@@ -216,12 +219,13 @@ pub(super) fn inflate_indexed(
             let span_sender = span_sender.clone();
             let (next, stop) = (&next, &stop);
             scope.spawn(move || {
+                let mut decoders = zinfo::Decoders::default();
                 while !stop.load(Ordering::Relaxed) {
                     let i = next.fetch_add(1, Ordering::Relaxed);
                     if i >= spans {
                         break;
                     }
-                    let result = index.extract_span(blob, i);
+                    let result = index.extract_span(blob, i, &mut decoders);
                     let failed = result.is_err();
                     if span_sender.send((i, result)).is_err() || failed {
                         break;

--- a/source/src/extract/spans.rs
+++ b/source/src/extract/spans.rs
@@ -218,7 +218,7 @@ fn plan_units(layers: &[Layer], work: &Work, plan: &Plan) -> Vec<Unit> {
 /// memory bound, and the cores end up queueing for the same bandwidth. On a
 /// sixteen core machine eight was the peak, and sixteen was worse than four
 /// on both wall clock and processor time.
-const MAX_WORKERS: usize = 8;
+pub(super) const MAX_WORKERS: usize = 8;
 
 fn workers(units: usize) -> usize {
     thread::available_parallelism()

--- a/source/src/zinfo.rs
+++ b/source/src/zinfo.rs
@@ -239,9 +239,9 @@ impl Index {
 
     /// Decompresses the span between checkpoint `i` and its successor (or the
     /// end of the stream) and verifies it against the recorded CRC.
-    pub fn extract_span(&self, blob: &[u8], i: usize) -> Result<Vec<u8>> {
+    pub fn extract_span(&self, blob: &[u8], i: usize, decoders: &mut Decoders) -> Result<Vec<u8>> {
         let mut out = Vec::new();
-        self.extract_span_into(blob, i, &mut out, 0, &mut Decoders::default())?;
+        self.extract_span_into(blob, i, &mut out, 0, decoders)?;
         Ok(out)
     }
 
@@ -772,7 +772,11 @@ mod tests {
         assert_eq!(index.uncompressed_len, data.len() as u64);
         let mut reassembled = Vec::new();
         for i in 0..index.checkpoints.len() {
-            reassembled.extend_from_slice(&index.extract_span(blob, i).unwrap());
+            reassembled.extend_from_slice(
+                &index
+                    .extract_span(blob, i, &mut Decoders::default())
+                    .unwrap(),
+            );
         }
         assert_eq!(reassembled, data);
     }
@@ -889,7 +893,9 @@ mod tests {
             .position(|p| !p.window.is_empty())
             .unwrap();
         // The bytes inflate fine; only the checksum can tell they are wrong.
-        let err = index.extract_span(&blob, i).unwrap_err();
+        let err = index
+            .extract_span(&blob, i, &mut Decoders::default())
+            .unwrap_err();
         assert!(err.to_string().contains("checksum"), "got: {err}");
     }
 
@@ -1006,7 +1012,9 @@ mod tests {
         let mut index = Index::build(Flavor::Zstd, &blob, 128 << 10).unwrap();
         // Claim the first span ends earlier than the frames it covers do.
         index.checkpoints[1].out_offset -= 1024;
-        let err = index.extract_span(&blob, 0).unwrap_err();
+        let err = index
+            .extract_span(&blob, 0, &mut Decoders::default())
+            .unwrap_err();
         assert!(
             err.to_string().contains("more than the index"),
             "got: {err}"


### PR DESCRIPTION
`spans::run` caps at eight workers because past that the cores queue for memory bandwidth and both clocks get worse. `pipeline::inflate_indexed`, which inflates spans for a layer the plan could not resolve, spawned `available_parallelism()` of them with no cap at all -- so the fallback route oversubscribed exactly what the primary route was tuned not to, and held a span buffer per thread while doing it. It also built a decompressor per span, which the last commit stopped doing everywhere else.

Measured on the full fixture with the route forced (20 of 20 layers resumed), nine interleaved rounds on this sixteen thread host:

```
peak RSS      327.3 MiB -> 255.0 MiB   -22.1%
minor faults    310,520 -> 308,803      -0.6%
clone/futex/mmap/munmap/mprotect: 1,801 fewer syscalls
```

Peak memory is the point: sixteen workers each held a span, and a span is megabytes. Wall and cpu say nothing here -- the baseline's cpu spread across those rounds was 57%, against 20% for the capped build, and min and median disagree on the sign. Steadier is worth having on its own.