### PR TITLE
Support for optimised FUSE backend startup via profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ cd source && bazel build //:bench_image //:bench_run
 - `//:bench_counts_test` guards the counts in CI. When it fails, something
   changed what the launcher asks of the kernel -- find out what before
   updating its numbers.
+- The served route has no harness. Measure it with a stand-in runtime that
+  reads part of the tree and compare `The container waited for N files`, which
+  is a count and so survives a busy host.
 
 ## Git
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,53 @@ Handing a file to the kernel to read and write itself, rather than through the
 launcher, needs a 6.9 kernel built with `CONFIG_FUSE_PASSTHROUGH` and the
 privilege to ask. `--verbose` says which of them the run got.
 
+### Fetching ahead
+
+A served file is paid for when the container opens it, one at a time and with
+the container waiting for each. What a container reads barely changes from run
+to run, so a recording of one run says what the next will want, and those files
+can be fetched before it asks and several at once.
+
+What a container reads is not something a build can work out, so a profile is
+recorded by running the container rather than by building it:
+
+```starlark
+load("@rules_oci_runtime//lib:defs.bzl", "oci_runtime_profile", "runc_binary")
+
+oci_runtime_profile(
+    name = "container_profile",
+    srcs = glob(["profiles/container.*.profile"], allow_empty = True),
+    record_to = "profiles/container",
+)
+
+runc_binary(
+    name = "container",
+    image = "@alpine",
+    profile = ":container_profile",
+)
+```
+
+```sh
+bazel run //:container -- --record-profile /bin/sh -c 'echo "Hello, world!"'
+```
+```
+recorded 4 files this run read into .../profiles/container.linux-amd64.profile, 4 in all over 1 runs
+```
+
+The profile is a sorted text file, one path a line with the number of runs that
+read it, and recording merges into it rather than replacing it: a container
+takes a different path through itself every time it is asked something
+different, and recording a few of them covers more than any one of them does.
+The name carries the platform because the run only saw one manifest of the
+image, and another platform's holds other files.
+
+The container starts as soon as the first file in the profile is there and the
+rest are fetched while it runs, giving way to whatever the container asks for
+itself; a profile that has gone stale therefore costs a lookup rather than a
+wait. `runc_binary` checks each profile against the image it is used with, so
+one left behind by a rename, or recorded against another image, fails the build
+instead.
+
 ### Extended attributes
 
 Extended attributes are not restored. The one images use in practice,
@@ -209,6 +256,9 @@ Flags accepted before the container command override the rule attributes:
 | `--rootless auto\|true\|false` | Use a user namespace. Defaults to `auto`. |
 | `--read-only` | Mount the container root filesystem read-only. |
 | `--rootfs auto\|fuse\|extract` | Serve the image or extract it. Defaults to `auto`, which serves it where the host and the image allow. |
+| `--profile PATH` | Fetch what a recorded profile names ahead of the container. Repeatable. |
+| `--record-profile[=PATH]` | Record what this run reads. Without a path it writes where the rule said to, and it serves the image or fails. |
+| `--prefetch-barrier COUNT` | How many of a profile's files to fetch before the container starts. Defaults to `1`. |
 | `--strict-xattrs BOOL` | Refuse an image that sets extended attributes. Defaults to `true`. |
 | `--keep-bundle` | Leave the generated bundle on disk for inspection. |
 | `--verbose` | Same as `RULES_OCI_RUNTIME_VERBOSE=1`. |

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -84,6 +84,64 @@ Register a `launcher_toolchain` to use a patched launcher instead.
 | <a id="launcher_toolchain-binary"></a>binary |  The launcher executable.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
+<a id="oci_runtime_profile"></a>
+
+## oci_runtime_profile
+
+<pre>
+load("@rules_oci_runtime//lib:defs.bzl", "oci_runtime_profile")
+
+oci_runtime_profile(<a href="#oci_runtime_profile-name">name</a>, <a href="#oci_runtime_profile-srcs">srcs</a>, <a href="#oci_runtime_profile-record_to">record_to</a>)
+</pre>
+
+Collects the profiles a `runc_binary` fetches ahead from.
+
+A profile says which files of an image a container actually read, so the next
+run can fetch them before it asks rather than pay for each one as it blocks.
+What a container reads is not something a build can work out, so profiles are
+recorded by running the container:
+
+```sh
+bazel run //:container -- --record-profile /bin/sh -c 'echo hello'
+```
+
+That writes `<record_to>.<os>-<arch>.profile` into the source tree, merging
+into whatever is there already, so recording several runs of a container
+accumulates what they all read. The platform is part of the name because the
+run only saw one manifest of the image, and another platform's would hold
+other files.
+
+Profiles are ordinary source files. They may not exist yet -- which is how the
+first recording gets to happen -- so glob for them:
+
+```starlark
+oci_runtime_profile(
+    name = "container_profile",
+    srcs = glob(["profiles/container.*.profile"], allow_empty = True),
+    record_to = "profiles/container",
+)
+
+runc_binary(
+    name = "container",
+    image = "@alpine",
+    profile = ":container_profile",
+)
+```
+
+`runc_binary` checks each profile against the image it is used with, so one
+left behind by a rename or recorded against another image fails the build
+rather than quietly fetching nothing.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="oci_runtime_profile-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="oci_runtime_profile-srcs"></a>srcs |  Recorded profiles, named `<record_to>.<os>-<arch>.profile`.<br><br>Empty is allowed and means nothing has been recorded yet: the container runs as it always has, and recording one is what fills this in.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="oci_runtime_profile-record_to"></a>record_to |  Package relative base path a recording writes to, defaulting to the target name.<br><br>The platform and the `.profile` suffix are added by the recording, so `profiles/container` records `profiles/container.linux-amd64.profile`.   | String | optional |  `""`  |
+
+
 <a id="runc_binary"></a>
 
 ## runc_binary
@@ -91,7 +149,8 @@ Register a `launcher_toolchain` to use a patched launcher instead.
 <pre>
 load("@rules_oci_runtime//lib:defs.bzl", "runc_binary")
 
-runc_binary(<a href="#runc_binary-name">name</a>, <a href="#runc_binary-data">data</a>, <a href="#runc_binary-env">env</a>, <a href="#runc_binary-hostname">hostname</a>, <a href="#runc_binary-image">image</a>, <a href="#runc_binary-index">index</a>, <a href="#runc_binary-mounts">mounts</a>, <a href="#runc_binary-read_only">read_only</a>, <a href="#runc_binary-strict_xattrs">strict_xattrs</a>, <a href="#runc_binary-workdir">workdir</a>)
+runc_binary(<a href="#runc_binary-name">name</a>, <a href="#runc_binary-data">data</a>, <a href="#runc_binary-env">env</a>, <a href="#runc_binary-hostname">hostname</a>, <a href="#runc_binary-image">image</a>, <a href="#runc_binary-index">index</a>, <a href="#runc_binary-mounts">mounts</a>, <a href="#runc_binary-profile">profile</a>, <a href="#runc_binary-read_only">read_only</a>, <a href="#runc_binary-strict_xattrs">strict_xattrs</a>,
+            <a href="#runc_binary-workdir">workdir</a>)
 </pre>
 
 Creates an executable that runs an OCI image with `runc`.
@@ -130,6 +189,7 @@ adding the module is all the setup needed on Linux amd64 and arm64.
 | <a id="runc_binary-image"></a>image |  An OCI image layout directory, such as an `oci_image` or `oci.pull` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="runc_binary-index"></a>index |  Index the layers at build time so the image can be served rather than extracted.<br><br>Each sidecar is a small file in the runfiles tree saying what a layer holds and where inflating it can resume; the image layout and its digests are unchanged. With one beside every layer the launcher can describe the whole root filesystem without reading it, mount that, and fetch a file's bytes only when something opens it. Without them it extracts the image, and where it does extract the sidecars still let it do so in parallel.<br><br>Indexing decompresses every layer once per build of the image, so switch it off if build time matters more than startup time.   | Boolean | optional |  `True`  |
 | <a id="runc_binary-mounts"></a>mounts |  Bind mounts, each `SOURCE:DESTINATION[:OPTIONS]`.<br><br>`OPTIONS` is a comma separated mount option list such as `ro` or `rw,noexec`, defaulting to `rw`. `$VAR` and `${VAR}` are expanded in `SOURCE` when the container starts, so `$BUILD_WORKSPACE_DIRECTORY:/src:ro` mounts the workspace.   | List of strings | optional |  `[]`  |
+| <a id="runc_binary-profile"></a>profile |  An `oci_runtime_profile` naming what this container reads, fetched ahead of it.<br><br>A served image costs a wait every time the container opens a file nothing has opened yet. A profile is the list of those files from a previous run, so they can be fetched before it asks and on more than one thread at a time. Requires `index = True`, since an image without the sidecars is extracted rather than served.<br><br>Profiles are recorded by running the container, not by building it: see `oci_runtime_profile`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="runc_binary-read_only"></a>read_only |  Mount the container root filesystem read-only.   | Boolean | optional |  `False`  |
 | <a id="runc_binary-strict_xattrs"></a>strict_xattrs |  Fail rather than run an image whose layers set extended attributes.<br><br>Extended attributes are never restored. The one that matters in practice, `security.capability`, needs a privilege the extraction does not have when it runs rootless, so a container built from such an image does not match it: a binary that expected a capability will not have one. Failing says so, rather than leaving it to be discovered at runtime.<br><br>Switch it off to extract the image anyway, dropping the attributes.   | Boolean | optional |  `True`  |
 | <a id="runc_binary-workdir"></a>workdir |  Working directory inside the container, overriding the image `WorkingDir`.   | String | optional |  `""`  |

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -1,11 +1,25 @@
 load("@rules_oci//oci:defs.bzl", "oci_image")
-load("@rules_oci_runtime//lib:defs.bzl", "runc_binary")
+load("@rules_oci_runtime//lib:defs.bzl", "oci_runtime_profile", "runc_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@tar.bzl", "tar")
 
 runc_binary(
     name = "container",
     image = "@alpine",
+)
+
+# The committed profile is checked against the image at build time, so a build
+# of this target is the check.
+oci_runtime_profile(
+    name = "container_profile",
+    srcs = glob(["profiles/container.*.profile"], allow_empty = True),
+    record_to = "profiles/container",
+)
+
+runc_binary(
+    name = "profiled_container",
+    image = "@alpine",
+    profile = ":container_profile",
 )
 
 runc_binary(
@@ -68,6 +82,7 @@ CASES = [
     "layer_indexes",
     "missing_command",
     "read_only_rootfs",
+    "recorded_profile",
     "rootfs_contents",
     "rule_env_and_workdir",
     "rule_mounts",
@@ -88,6 +103,7 @@ CASES = [
             ":configured_container",
             ":container",
             ":mounting_container",
+            ":profiled_container",
             ":read_only_container",
             ":zstd_container",
         ],
@@ -95,6 +111,7 @@ CASES = [
             "CONFIGURED_CONTAINER": "$(rlocationpath :configured_container)",
             "CONTAINER": "$(rlocationpath :container)",
             "MOUNTING_CONTAINER": "$(rlocationpath :mounting_container)",
+            "PROFILED_CONTAINER": "$(rlocationpath :profiled_container)",
             "READ_ONLY_CONTAINER": "$(rlocationpath :read_only_container)",
             "ZSTD_CONTAINER": "$(rlocationpath :zstd_container)",
         },

--- a/e2e/smoke/cases.sh
+++ b/e2e/smoke/cases.sh
@@ -10,6 +10,7 @@ container="${runfiles}/${CONTAINER}"
 configured_container="${runfiles}/${CONFIGURED_CONTAINER}"
 read_only_container="${runfiles}/${READ_ONLY_CONTAINER}"
 mounting_container="${runfiles}/${MOUNTING_CONTAINER}"
+profiled_container="${runfiles}/${PROFILED_CONTAINER}"
 zstd_container="${runfiles}/${ZSTD_CONTAINER}"
 
 failures=0
@@ -259,6 +260,69 @@ case_served_rootfs() {
   assert_equals "written" "$served" "a served rootfs is writable"
   served=$("$container" --rootfs=fuse /bin/cat /etc/alpine-release </dev/null)
   assert_equals "${extracted%%$'\n'*}" "$served" "the next run sees the image again"
+}
+
+# What a container read is recorded from a run of it and fetched ahead of the
+# next one. Recording is a run time thing rather than a build time one, so this
+# records into the test's own directory rather than a source tree.
+case_recorded_profile() {
+  local base="${TEST_TMPDIR}/profiles/alpine"
+  local platform err
+  err="${TEST_TMPDIR}/record.err"
+
+  RULES_OCI_RUNTIME_VERBOSE=1 "$container" --record-profile="$base" \
+    /bin/sh -c 'cat /etc/alpine-release >/dev/null' </dev/null 2>"$err"
+  if grep -q "cannot serve the image" "$err"; then
+    return
+  fi
+
+  local profile
+  profile=$(echo "${base}".*.profile)
+  if [[ ! -f "$profile" ]]; then
+    fail "recording wrote no profile: $(cat "$err")"
+    return
+  fi
+  # The platform is in the name so two of them cannot land on one file.
+  assert_contains "$profile" "$(uname -s | tr 'A-Z' 'a-z')-" "the profile is named for a platform"
+  assert_contains "$(cat "$profile")" "/etc/alpine-release" "the file the container read"
+  assert_contains "$(cat "$profile")" "runs 1" "one recorded run"
+
+  # A second recording adds to the first rather than replacing it.
+  "$container" --record-profile="$base" \
+    /bin/sh -c 'cat /etc/hostname >/dev/null' </dev/null 2>/dev/null
+  assert_contains "$(cat "$profile")" "runs 2" "a second recorded run"
+  assert_contains "$(cat "$profile")" "/etc/alpine-release" "what the first run read"
+  assert_equals "1" "$(grep -c ' /etc/alpine-release$' "$profile")" "one line per file"
+
+  # Reading it back fetches those files before the container asks for them.
+  local output
+  output=$(RULES_OCI_RUNTIME_VERBOSE=1 "$container" --rootfs=fuse --profile "$profile" \
+    /bin/cat /etc/alpine-release </dev/null 2>"${TEST_TMPDIR}/replay.err")
+  assert_equals "$("$container" --rootfs=extract /bin/cat /etc/alpine-release </dev/null)" \
+    "$output" "a profiled run reads what an extracted one does"
+  assert_contains "$(cat "${TEST_TMPDIR}/replay.err")" "ahead of the container" "files fetched ahead"
+  # The point of the profile: nothing the container opened had to be fetched
+  # while it waited.
+  assert_contains "$(cat "${TEST_TMPDIR}/replay.err")" "waited for 0 files" "no blocking fetches"
+
+  # There is nothing to record from a rootfs that is written out in full before
+  # the container starts.
+  "$container" --rootfs=extract --record-profile="$base" /bin/true </dev/null \
+    2>"${TEST_TMPDIR}/extracted.err"
+  assert_contains "$(cat "${TEST_TMPDIR}/extracted.err")" "nothing to record" \
+    "recording from an extracted rootfs"
+
+  # A profile recorded for another platform is not this one's to use.
+  local other="${TEST_TMPDIR}/other.linux-nosucharch.profile"
+  sed 's|^platform .*|platform linux/nosucharch|' "$profile" >"$other"
+  RULES_OCI_RUNTIME_VERBOSE=1 "$container" --rootfs=fuse --profile "$other" \
+    /bin/true </dev/null 2>"${TEST_TMPDIR}/other.err"
+  assert_contains "$(cat "${TEST_TMPDIR}/other.err")" "Ignoring" "another platform's profile"
+
+  # The rule wires its own profile in, whether or not one has been recorded.
+  output=$("$profiled_container" /bin/cat /etc/alpine-release </dev/null)
+  assert_equals "$("$container" --rootfs=extract /bin/cat /etc/alpine-release </dev/null)" \
+    "$output" "the rule's profiled container"
 }
 
 # A bundle goes away with the launcher however the launcher goes. A served

--- a/e2e/smoke/profiles/container.linux-amd64.profile
+++ b/e2e/smoke/profiles/container.linux-amd64.profile
@@ -1,0 +1,9 @@
+# oci-runtime-profile 1
+platform linux/amd64
+image sha256:706db57fb2063f39f69632c5b5c9c439633fda35110e65587c5d85553fd1cc38
+runs 2
+2 1 /bin/busybox
+1 3 /etc/alpine-release
+2 0 /etc/passwd
+2 2 /lib/ld-musl-x86_64.so.1
+1 3 /usr/lib/os-release

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -7,6 +7,7 @@ bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     deps = [
+        "//lib/private:profile",
         "//lib/private:runc_binary",
         "//lib/private:toolchains",
     ],

--- a/lib/defs.bzl
+++ b/lib/defs.bzl
@@ -1,5 +1,6 @@
 """Bazel rules for running OCI container images."""
 
+load("//lib/private:profile.bzl", _oci_runtime_profile = "oci_runtime_profile")
 load("//lib/private:runc_binary.bzl", _runc_binary = "runc_binary")
 load(
     "//lib/private:toolchains.bzl",
@@ -8,5 +9,6 @@ load(
 )
 
 runc_binary = _runc_binary
+oci_runtime_profile = _oci_runtime_profile
 launcher_toolchain = _launcher_toolchain
 container_runtime_toolchain = _container_runtime_toolchain

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -18,7 +18,19 @@ bzl_library(
         "//docs:__subpackages__",
         "//lib:__subpackages__",
     ],
-    deps = [":toolchains"],
+    deps = [
+        ":profile",
+        ":toolchains",
+    ],
+)
+
+bzl_library(
+    name = "profile",
+    srcs = ["profile.bzl"],
+    visibility = [
+        "//docs:__subpackages__",
+        "//lib:__subpackages__",
+    ],
 )
 
 bzl_library(

--- a/lib/private/profile.bzl
+++ b/lib/private/profile.bzl
@@ -1,0 +1,110 @@
+"""Profiles of what a container reads, recorded outside Bazel."""
+
+visibility(["//lib/...", "//docs/..."])
+
+OciRuntimeProfileInfo = provider(
+    doc = "Recorded profiles of what a container read, and where new recordings go.",
+    fields = {
+        "files": "The profile files, one per platform. Possibly none of them.",
+        "record_to": "Workspace relative base path a recording writes to, without the platform qualifier or suffix.",
+    },
+)
+
+_SUFFIX = ".profile"
+
+_DOC = """Collects the profiles a `runc_binary` fetches ahead from.
+
+A profile says which files of an image a container actually read, so the next
+run can fetch them before it asks rather than pay for each one as it blocks.
+What a container reads is not something a build can work out, so profiles are
+recorded by running the container:
+
+```sh
+bazel run //:container -- --record-profile /bin/sh -c 'echo hello'
+```
+
+That writes `<record_to>.<os>-<arch>.profile` into the source tree, merging
+into whatever is there already, so recording several runs of a container
+accumulates what they all read. The platform is part of the name because the
+run only saw one manifest of the image, and another platform's would hold
+other files.
+
+Profiles are ordinary source files. They may not exist yet -- which is how the
+first recording gets to happen -- so glob for them:
+
+```starlark
+oci_runtime_profile(
+    name = "container_profile",
+    srcs = glob(["profiles/container.*.profile"], allow_empty = True),
+    record_to = "profiles/container",
+)
+
+runc_binary(
+    name = "container",
+    image = "@alpine",
+    profile = ":container_profile",
+)
+```
+
+`runc_binary` checks each profile against the image it is used with, so one
+left behind by a rename or recorded against another image fails the build
+rather than quietly fetching nothing.
+"""
+
+def _oci_runtime_profile_impl(ctx):
+    # type: (ctx) -> list
+    record_to = ctx.attr.record_to or ctx.label.name
+    base = record_to.rsplit("/", 1)[-1]
+    for src in ctx.files.srcs:
+        name = src.basename
+        if not name.endswith(_SUFFIX):
+            fail("{}: {} is not named like a profile, which ends in `{}`".format(
+                ctx.label,
+                src.short_path,
+                _SUFFIX,
+            ))
+        qualified = name[:-len(_SUFFIX)]
+        parts = qualified.rsplit(".", 1)
+        if len(parts) != 2 or "-" not in parts[1]:
+            fail("{}: {} does not name a platform, expected `{}.<os>-<arch>{}`".format(
+                ctx.label,
+                src.short_path,
+                base,
+                _SUFFIX,
+            ))
+        if parts[0] != base:
+            fail("{}: {} is not a profile of `{}`, which is where recordings go".format(
+                ctx.label,
+                src.short_path,
+                record_to,
+            ))
+
+    return [
+        DefaultInfo(files = depset(ctx.files.srcs)),
+        OciRuntimeProfileInfo(
+            files = ctx.files.srcs,
+            record_to = "{}/{}".format(ctx.label.package, record_to) if ctx.label.package else record_to,
+        ),
+    ]
+
+oci_runtime_profile = rule(
+    implementation = _oci_runtime_profile_impl,
+    doc = _DOC,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = [_SUFFIX],
+            doc = """Recorded profiles, named `<record_to>.<os>-<arch>.profile`.
+
+Empty is allowed and means nothing has been recorded yet: the container runs
+as it always has, and recording one is what fills this in.
+""",
+        ),
+        "record_to": attr.string(
+            doc = """Package relative base path a recording writes to, defaulting to the target name.
+
+The platform and the `.profile` suffix are added by the recording, so
+`profiles/container` records `profiles/container.linux-amd64.profile`.
+""",
+        ),
+    },
+)

--- a/lib/private/runc_binary.bzl
+++ b/lib/private/runc_binary.bzl
@@ -1,5 +1,6 @@
 """Implementation of `runc_binary`."""
 
+load(":profile.bzl", "OciRuntimeProfileInfo")
 load(
     ":toolchains.bzl",
     "CONTAINER_RUNTIME_TOOLCHAIN_TYPE",
@@ -93,7 +94,7 @@ def _runc_binary_impl(ctx):
     if ctx.attr.index:
         index_dir = ctx.actions.declare_directory(ctx.label.name + ".zinfo")
         ctx.actions.run(
-            executable = ctx.attr._indexer[DefaultInfo].files_to_run,
+            executable = ctx.attr._tool[DefaultInfo].files_to_run,
             arguments = ["index", "--layout", layout.path, "--output", index_dir.path],
             inputs = [layout],
             outputs = [index_dir],
@@ -102,6 +103,12 @@ def _runc_binary_impl(ctx):
         )
         content["index"] = _rlocation_path(ctx, index_dir)
         indexes.append(index_dir)
+
+    profiles, checks = _profiles(ctx, layout, indexes)
+    if profiles:
+        content["profiles"] = [_rlocation_path(ctx, profile) for profile in profiles]
+    if ctx.attr.profile:
+        content["record_to"] = ctx.attr.profile[OciRuntimeProfileInfo].record_to
 
     config = ctx.actions.declare_file(ctx.label.name + ".launch.json")
     ctx.actions.write(
@@ -114,7 +121,7 @@ def _runc_binary_impl(ctx):
         config,
         launcher_toolchain.binary,
         runtime_toolchain.binary,
-    ] + indexes).merge_all([
+    ] + indexes + profiles).merge_all([
         launcher_toolchain.runfiles,
         runtime_toolchain.runfiles,
         ctx.attr.image[DefaultInfo].default_runfiles,
@@ -126,7 +133,47 @@ def _runc_binary_impl(ctx):
             files = depset([launcher, config] + indexes),
             runfiles = runfiles,
         ),
+        OutputGroupInfo(_validation = depset(checks)),
     ]
+
+def _profiles(ctx, layout, indexes):
+    # type: (ctx, File, list) -> tuple
+    """The profiles to fetch ahead from, and the checks that they still apply.
+
+    A profile that has stopped describing the image costs a lookup and nothing
+    else at run time, so nothing fails there. Here is where saying so is any
+    use: a profile left behind by a rename, or recorded against another image,
+    still looks like a profile and no longer buys what it claims.
+    """
+    if not ctx.attr.profile:
+        return [], []
+    profiles = ctx.attr.profile[OciRuntimeProfileInfo].files
+    if profiles and not indexes:
+        fail("{}: a profile needs `index = True`, since an image without the layer sidecars is extracted rather than served".format(ctx.label))
+
+    checks = []
+    for profile in profiles:
+        checked = ctx.actions.declare_file("{}.{}.checked".format(ctx.label.name, profile.basename))
+        ctx.actions.run(
+            executable = ctx.attr._tool[DefaultInfo].files_to_run,
+            arguments = [
+                "profile",
+                "--profile",
+                profile.path,
+                "--layout",
+                layout.path,
+                "--index",
+                indexes[0].path,
+                "--stamp",
+                checked.path,
+            ],
+            inputs = [layout, profile] + indexes,
+            outputs = [checked],
+            mnemonic = "OciProfileCheck",
+            progress_message = "Checking " + profile.short_path + " against %{label}",
+        )
+        checks.append(checked)
+    return profiles, checks
 
 runc_binary = rule(
     implementation = _runc_binary_impl,
@@ -189,7 +236,21 @@ off if build time matters more than startup time.
             allow_files = True,
             doc = "Extra files to make available in the runfiles tree, for use with `mounts`.",
         ),
-        "_indexer": attr.label(
+        "profile": attr.label(
+            providers = [OciRuntimeProfileInfo],
+            doc = """An `oci_runtime_profile` naming what this container reads, fetched ahead of it.
+
+A served image costs a wait every time the container opens a file nothing has
+opened yet. A profile is the list of those files from a previous run, so they
+can be fetched before it asks and on more than one thread at a time. Requires
+`index = True`, since an image without the sidecars is extracted rather than
+served.
+
+Profiles are recorded by running the container, not by building it: see
+`oci_runtime_profile`.
+""",
+        ),
+        "_tool": attr.label(
             default = ":current_launcher",
             executable = True,
             cfg = "exec",

--- a/source/README.md
+++ b/source/README.md
@@ -65,6 +65,24 @@ nothing: entries placed, what the plan skipped, and the syscalls each route
 makes. Its numbers come from `bench_image --profile small`; when the generator
 changes, run the test and update them from what it reports.
 
+### The served route
+
+`bench_run` measures extraction, and has no served mode: what a served rootfs
+costs depends on what the container reads, which is not something the harness
+knows. Until it has one, run the launcher against a generated layout with a
+stand-in runtime that reads part of the tree, and read the count the launcher
+reports itself:
+
+```
+.bazel/bin/oci_runtime run --layout /tmp/bench-full --index /tmp/idx-full \
+    --rootfs=fuse --runtime ./reads-some-files.sh --verbose 2>&1 | grep waited
+```
+
+`The container waited for N files to be fetched` is the number to compare. It
+is the count of opens that had to inflate a span before they could be answered,
+so it does not move with the host the way the clock does, and it is what a
+profile is meant to drive to zero.
+
 ## Profile-guided optimisation
 
 Release launchers are built against `pgo/oci_runtime.profdata`, which is

--- a/source/src/cli.rs
+++ b/source/src/cli.rs
@@ -21,6 +21,29 @@ pub enum Command {
     Run(Box<RunArgs>),
     /// Build parallel-decompression checkpoint indexes for gzip blobs.
     Index(IndexArgs),
+    /// Check that a recorded profile still describes an image.
+    Profile(ProfileArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ProfileArgs {
+    /// The profile to check.
+    #[arg(long, value_name = "PATH")]
+    pub profile: Utf8PathBuf,
+
+    /// Image layout the profile is used with.
+    #[arg(long, value_name = "DIR")]
+    pub layout: Utf8PathBuf,
+
+    /// Directory of the layer sidecars, which is what says what the image
+    /// holds without reading it.
+    #[arg(long, value_name = "DIR")]
+    pub index: Utf8PathBuf,
+
+    /// File to write when the profile passes, for a build that needs an
+    /// output to depend on.
+    #[arg(long, value_name = "PATH")]
+    pub stamp: Option<Utf8PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -69,6 +92,34 @@ pub struct RunArgs {
     /// compressed layer.
     #[arg(long, value_name = "DIR")]
     pub index: Option<Utf8PathBuf>,
+
+    /// Profile of what a container read, fetched ahead of this one. Repeatable:
+    /// the profile recorded for the image platform in use is the one read.
+    #[arg(long = "profile", value_name = "PATH")]
+    pub profiles: Vec<Utf8PathBuf>,
+
+    /// Record what the container reads, merging into whatever profile is
+    /// there already. Given no `=PATH` it records where the rule said to,
+    /// under `$BUILD_WORKSPACE_DIRECTORY`; the platform is appended to the
+    /// name either way.
+    #[arg(
+        long,
+        value_name = "PATH",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = ""
+    )]
+    pub record_profile: Option<Utf8PathBuf>,
+
+    /// How many of a profile's files to fetch before the container starts. The
+    /// rest are fetched while it runs.
+    #[arg(long, value_name = "COUNT", default_value_t = 1)]
+    pub prefetch_barrier: usize,
+
+    /// Where `--record-profile` writes when given no path, relative to
+    /// `$BUILD_WORKSPACE_DIRECTORY`. Supplied by the rule.
+    #[arg(long, value_name = "PATH")]
+    pub profile_base: Option<Utf8PathBuf>,
 
     /// Additional environment variables, overriding the image.
     #[arg(long = "env", short = 'e', value_name = "NAME=VALUE")]

--- a/source/src/error.rs
+++ b/source/src/error.rs
@@ -67,6 +67,12 @@ pub enum Error {
     },
     /// `--rootfs=fuse` was asked for and the image could not be served.
     CannotServe(String),
+    /// A profile file is not one, or does not describe the image it was
+    /// handed to.
+    Profile {
+        path: String,
+        message: String,
+    },
 }
 
 impl Error {
@@ -160,6 +166,7 @@ impl fmt::Display for Error {
                 f,
                 "cannot serve the image: {reason}; pass --rootfs=auto to extract it instead"
             ),
+            Error::Profile { path, message } => write!(f, "profile {path} {message}"),
         }
     }
 }

--- a/source/src/launcher.rs
+++ b/source/src/launcher.rs
@@ -17,6 +17,14 @@ struct Config {
     runtime: String,
     #[serde(default)]
     index: Option<String>,
+    /// Profiles of what this container read before, one per platform.
+    #[serde(default)]
+    profiles: Vec<String>,
+    /// Where a recording goes, relative to the workspace rather than the
+    /// runfiles: a profile is a source file, and the runfiles copy of one is
+    /// read only and thrown away.
+    #[serde(default)]
+    record_to: Option<String>,
     #[serde(default)]
     args: Vec<String>,
 }
@@ -78,6 +86,14 @@ impl Config {
             argv.push("--index".to_string());
             argv.push(runfiles.join(index).into_string());
         }
+        for profile in &self.profiles {
+            argv.push("--profile".to_string());
+            argv.push(runfiles.join(profile).into_string());
+        }
+        if let Some(record_to) = &self.record_to {
+            argv.push("--profile-base".to_string());
+            argv.push(record_to.clone());
+        }
         argv.extend(self.args.iter().cloned());
         argv.extend(user.iter().cloned());
         argv
@@ -129,6 +145,27 @@ mod tests {
         assert_eq!(
             &argv[argv.len() - 2..],
             ["--index", "/tmp/rf/ws/pkg/container.zinfo"]
+        );
+    }
+
+    #[test]
+    fn profiles_are_resolved_and_the_recording_base_is_not() {
+        let config: Config = serde_json::from_str(
+            r#"{"layout": "l", "runtime": "r",
+                "profiles": ["ws/pkg/c.linux-amd64.profile"],
+                "record_to": "pkg/profiles/c"}"#,
+        )
+        .expect("config");
+        let argv = config.command_line("launcher", Utf8Path::new("/tmp/rf"), &[]);
+        assert_eq!(
+            &argv[argv.len() - 4..],
+            [
+                "--profile",
+                "/tmp/rf/ws/pkg/c.linux-amd64.profile",
+                // Recorded into the source tree, which is not the runfiles.
+                "--profile-base",
+                "pkg/profiles/c",
+            ]
         );
     }
 

--- a/source/src/lazy/ahead.rs
+++ b/source/src/lazy/ahead.rs
@@ -1,0 +1,139 @@
+//! Fetching what the container is about to read, before it asks.
+//!
+//! A served file costs a span of inflating the first time something opens it,
+//! and the container waits for all of it. What it opens is nearly the same on
+//! every run, so a recorded list of paths is a list of waits that can happen
+//! ahead of time instead, on threads of their own.
+//!
+//! Ahead of time is not the same as up front. The container starts as soon as
+//! the file it blocks on first is there, and the rest is fetched underneath it
+//! while it runs; a profile is a guess, and the reads that disprove it must not
+//! queue behind it.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread::{self, JoinHandle};
+
+use super::fs::Rootfs;
+use super::tree::Names;
+use crate::log::log;
+use crate::profile::{self, Profile};
+
+/// Fetching ahead running on this thread until it has done enough for the
+/// container to start, and on its own threads after that.
+pub struct Ahead {
+    stop: Arc<AtomicBool>,
+    fetched: Arc<AtomicUsize>,
+    wanted: usize,
+    workers: Vec<JoinHandle<()>>,
+}
+
+impl Ahead {
+    /// Fetches the first `barrier` files the profile names, then hands the
+    /// rest to `workers` threads and returns.
+    pub fn start(
+        rootfs: &Rootfs,
+        names: &Names,
+        profile: &Profile,
+        barrier: usize,
+        workers: usize,
+    ) -> Ahead {
+        let (order, missing) = resolve(profile, names);
+        if missing > 0 {
+            log!("{missing} of the profile's files are not in this image");
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        let fetched = Arc::new(AtomicUsize::new(0));
+        let wanted = order.len();
+
+        // The container is held up by exactly this much, and a fetch reaches
+        // the whole span its file is in, so one entry is usually the whole of
+        // the first read.
+        for &ino in order.iter().take(barrier) {
+            rootfs.fetch_ahead(ino);
+            fetched.fetch_add(1, Ordering::Relaxed);
+        }
+        log!(
+            "Fetching {} files ahead of the container, {} of them before it starts",
+            wanted,
+            barrier.min(wanted)
+        );
+
+        let order = Arc::new(order);
+        let cursor = Arc::new(AtomicUsize::new(barrier));
+        let workers = (0..workers.min(wanted.saturating_sub(barrier)))
+            .map(|_| {
+                let rootfs = rootfs.clone();
+                let order = order.clone();
+                let cursor = cursor.clone();
+                let stop = stop.clone();
+                let fetched = fetched.clone();
+                thread::spawn(move || {
+                    while !stop.load(Ordering::Relaxed) {
+                        let at = cursor.fetch_add(1, Ordering::Relaxed);
+                        let Some(&ino) = order.get(at) else {
+                            break;
+                        };
+                        rootfs.fetch_ahead(ino);
+                        fetched.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+            })
+            .collect();
+
+        Ahead {
+            stop,
+            fetched,
+            wanted,
+            workers,
+        }
+    }
+
+    /// Gives up on whatever is left.
+    ///
+    /// The container is what this was for, so once it has gone the rest is
+    /// work nobody is waiting for: a run that failed a second in should not
+    /// spend a minute finishing a fetch of the image.
+    pub fn stop(&mut self) {
+        if self.workers.is_empty() {
+            return;
+        }
+        self.stop.store(true, Ordering::Relaxed);
+        for worker in self.workers.drain(..) {
+            let _ = worker.join();
+        }
+        log!(
+            "Fetched {} of the {} files the profile named",
+            self.fetched.load(Ordering::Relaxed),
+            self.wanted
+        );
+    }
+}
+
+impl Drop for Ahead {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// The inodes to fetch, first read first, and how many of the profile's paths
+/// this image no longer has.
+///
+/// A profile is recorded against one build of an image and used against the
+/// next, so paths do fall out of it. That is what the build time check is for;
+/// here it is only worth counting.
+fn resolve(profile: &Profile, names: &Names) -> (Vec<u64>, usize) {
+    let mut order = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut missing = 0;
+    for path in profile.ordered() {
+        // Hard linked names are one file, and fetching it twice is fetching
+        // its span twice.
+        match names.ino(&profile::to_entry_path(path)) {
+            Some(ino) if seen.insert(ino) => order.push(ino),
+            Some(_) => {}
+            None => missing += 1,
+        }
+    }
+    (order, missing)
+}

--- a/source/src/lazy/fs.rs
+++ b/source/src/lazy/fs.rs
@@ -13,14 +13,14 @@
 //! move, and two names for one file are two names for one backing file.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{FileExt, MetadataExt};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak};
+use std::sync::{Arc, Condvar, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak};
 use std::time::{Duration, UNIX_EPOCH};
 
 use fuser::{
@@ -68,6 +68,7 @@ impl Rootfs {
         backing: PathBuf,
         uid: u32,
         gid: u32,
+        recorder: Option<Arc<Recorder>>,
     ) -> Rootfs {
         Rootfs {
             served: Arc::new(Served {
@@ -83,6 +84,9 @@ impl Rootfs {
                 next_handle: AtomicU64::new(1),
                 backings: Mutex::new(HashMap::new()),
                 passthrough: AtomicBool::new(false),
+                recorder,
+                demand: Demand::default(),
+                waited: AtomicU64::new(0),
             }),
         }
     }
@@ -128,6 +132,99 @@ pub struct Served {
     /// Whether the kernel agreed to take files over at all. Cleared when it
     /// turns out to want a privilege this process does not have.
     passthrough: AtomicBool,
+    /// Where a recording run writes down what the container opened.
+    recorder: Option<Arc<Recorder>>,
+    /// What the container is waiting on right now, which anything fetching
+    /// ahead of it has to give way to.
+    demand: Demand,
+    /// How many files the container opened and then had to wait for. What
+    /// fetching ahead is for is this number, and unlike a clock it says the
+    /// same thing on a busy host as on an idle one.
+    waited: AtomicU64,
+}
+
+/// The image files something opened, in the order it reached them.
+///
+/// Recorded where the kernel asks rather than where a body is fetched: a run
+/// that is fetching ahead from a profile fetches files nothing ever opens, and
+/// a recording taken at the fetch would write those down as reads and grow a
+/// profile that can never shrink.
+pub struct Recorder {
+    /// The image's name for each inode. An inode with none here was made by
+    /// the container, and what the container made is not the image's to fetch.
+    names: Vec<Vec<u8>>,
+    opened: Mutex<(HashSet<u64>, Vec<u64>)>,
+}
+
+impl Recorder {
+    pub fn new(names: Vec<Vec<u8>>) -> Recorder {
+        Recorder {
+            names,
+            opened: Mutex::new((HashSet::new(), Vec::new())),
+        }
+    }
+
+    fn saw(&self, ino: u64) {
+        let named = ino
+            .checked_sub(1)
+            .and_then(|at| self.names.get(at as usize))
+            .is_some_and(|name| !name.is_empty());
+        if !named {
+            return;
+        }
+        let mut opened = self.opened.lock().unwrap_or_else(|err| err.into_inner());
+        if opened.0.insert(ino) {
+            opened.1.push(ino);
+        }
+    }
+
+    /// What was opened, first opened first, as the entry tables name it.
+    pub fn recorded(&self) -> Vec<Vec<u8>> {
+        let opened = self.opened.lock().unwrap_or_else(|err| err.into_inner());
+        opened
+            .1
+            .iter()
+            .map(|&ino| self.names[ino as usize - 1].clone())
+            .collect()
+    }
+}
+
+/// How many fetches the container itself is waiting on.
+///
+/// A profile is a guess, and the run where it guessed wrong is the one that
+/// matters: a read that arrives while the whole pool is fetching something
+/// else would queue behind work nothing asked for. Counting the reads lets
+/// the pool stand aside until they are answered.
+#[derive(Default)]
+pub struct Demand {
+    waiting: Mutex<usize>,
+    idle: Condvar,
+}
+
+impl Demand {
+    /// Blocks while the container is waiting on a fetch of its own.
+    fn wait_out(&self) {
+        let mut waiting = self.waiting.lock().unwrap_or_else(|err| err.into_inner());
+        while *waiting > 0 {
+            waiting = self
+                .idle
+                .wait(waiting)
+                .unwrap_or_else(|err| err.into_inner());
+        }
+    }
+
+    fn entered(&self) {
+        *self.waiting.lock().unwrap_or_else(|err| err.into_inner()) += 1;
+    }
+
+    fn left(&self) {
+        let mut waiting = self.waiting.lock().unwrap_or_else(|err| err.into_inner());
+        *waiting -= 1;
+        if *waiting == 0 {
+            drop(waiting);
+            self.idle.notify_all();
+        }
+    }
 }
 
 /// An open file, and the reason the kernel may not be asking about it.
@@ -167,6 +264,9 @@ impl Served {
     /// Fetches a file's bytes if this is the first time anything asked for
     /// them, and with them the rest of the span they are in.
     ///
+    /// Answers whether anything had to be fetched, which is what says a
+    /// caller waited rather than found the file already there.
+    ///
     /// The span is what inflating reaches whatever was asked for, so placing
     /// only the file that was asked for would inflate the same span again for
     /// the next one. Reading a rootfs right through costs what extracting it
@@ -175,9 +275,9 @@ impl Served {
     /// The tree lock is not held while a span is inflated. That is the one
     /// slow thing here, and holding it would stop every other request for as
     /// long as it took.
-    fn fetch(&self, ino: u64) -> Result<(), Errno> {
+    fn fetch(&self, ino: u64) -> Result<bool, Errno> {
         let Some((body, _)) = self.owed(ino)? else {
-            return Ok(());
+            return Ok(false);
         };
         let claim = self.source.span_of(body) * self.layers + body.layer as usize;
         // The lock guards nothing of its own, so a worker that panicked while
@@ -187,7 +287,7 @@ impl Served {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         // Whoever held the claim was inflating this very span.
         let Some((body, _)) = self.owed(ino)? else {
-            return Ok(());
+            return Ok(false);
         };
 
         SCRATCH
@@ -195,7 +295,31 @@ impl Served {
             .map_err(|err| {
                 crate::log::warn(format!("could not fetch an image file: {err}"));
                 Errno::EIO
-            })
+            })?;
+        Ok(true)
+    }
+
+    /// Fetches for the container itself. What the container is waiting on is
+    /// counted while it waits, so anything fetching ahead of it stands aside.
+    fn fetch_now(&self, ino: u64) -> Result<(), Errno> {
+        self.demand.entered();
+        let fetched = self.fetch(ino);
+        self.demand.left();
+        if matches!(fetched, Ok(true)) {
+            self.waited.fetch_add(1, Ordering::Relaxed);
+        }
+        fetched.map(|_| ())
+    }
+
+    /// Fetches a file the container has not asked for yet.
+    pub fn fetch_ahead(&self, ino: u64) {
+        self.demand.wait_out();
+        let _ = self.fetch(ino);
+    }
+
+    /// How many files the container opened and had to wait to be fetched.
+    pub fn waited(&self) -> u64 {
+        self.waited.load(Ordering::Relaxed)
     }
 
     fn fetch_span(&self, body: Body, scratch: &mut Scratch) -> crate::error::Result<()> {
@@ -247,7 +371,7 @@ impl Served {
     }
 
     fn open_backing(&self, ino: u64) -> Result<Arc<File>, Errno> {
-        self.fetch(ino)?;
+        self.fetch_now(ino)?;
         let file = fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -480,7 +604,7 @@ impl Filesystem for Rootfs {
         // Ownership is not the image's to give: extraction leaves everything
         // owned by whoever ran it, and so does this.
         if let Some(size) = size {
-            answer!(reply, self.fetch(ino.0));
+            answer!(reply, self.fetch_now(ino.0));
             let file = answer!(
                 reply,
                 fs::OpenOptions::new()
@@ -523,6 +647,9 @@ impl Filesystem for Rootfs {
     }
 
     fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        if let Some(recorder) = &self.recorder {
+            recorder.saw(ino.0);
+        }
         let file = answer!(reply, self.open_backing(ino.0));
         match self.backing(ino.0, &file, |fd| reply.open_backing(fd)) {
             Some(backing) => {

--- a/source/src/lazy/mod.rs
+++ b/source/src/lazy/mod.rs
@@ -12,13 +12,12 @@
 //! # Fetching ahead
 //!
 //! What a container reads is nearly the same on every run of it, so a recorded
-//! list of paths would say what to fetch before it asks. There is nothing to
-//! build for that beyond the recording and the list: [`fs::Rootfs`] resolves a
-//! path to an inode through the same tree `lookup` uses, and fetching one is
-//! safe from any thread and already reaches the whole span the file is in. A
-//! profile is therefore a walk of paths handed to the same fetch a read takes,
-//! on a pool, between the mount going up here and the bundle reaching runc.
+//! list of paths says what to fetch before it asks. [`ahead`] fetches that
+//! list, and a recording run writes it down where the kernel asks rather than
+//! where a body is fetched, so a run doing both does not record its own
+//! guesses as reads.
 
+mod ahead;
 mod fs;
 mod source;
 mod tree;
@@ -27,6 +26,7 @@ use std::fs::OpenOptions;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::thread;
 
 use camino::Utf8Path;
@@ -37,7 +37,11 @@ use crate::error::{Error, IoContext, Result};
 use crate::extract::RootfsExtractor;
 use crate::image::{Descriptor, Layout};
 use crate::log::{log, warning};
+use crate::profile::Profile;
 use crate::sys;
+
+use self::ahead::Ahead;
+use self::fs::Recorder;
 
 /// The character device every FUSE mount goes through. Its absence is the
 /// clearest sign a host cannot serve one.
@@ -51,6 +55,16 @@ const FUSE_CONF: &str = "/etc/fuse.conf";
 /// threads only queue for the same locks.
 const MAX_WORKERS: usize = 8;
 
+/// What a run does about the files the container has not asked for yet.
+pub struct Fetching<'a> {
+    /// The profile to fetch ahead from, where a run was given one.
+    pub profile: Option<&'a Profile>,
+    /// Whether to write down what the container opens.
+    pub record: bool,
+    /// How many of the profile's files to fetch before the container starts.
+    pub barrier: usize,
+}
+
 /// A live mount. Dropping it unmounts, which has to happen before the bundle
 /// holding the mount point is taken away.
 pub struct Mount {
@@ -59,6 +73,25 @@ pub struct Mount {
     /// Whether a helper is waiting to take the mount down when this process
     /// goes, which changes who has to take it down when it goes willingly.
     automatic: bool,
+    ahead: Option<Ahead>,
+    recorder: Option<Arc<Recorder>>,
+    served: fs::Rootfs,
+}
+
+impl Mount {
+    /// Stops fetching ahead, which is called for when the container it was
+    /// for has gone.
+    pub fn settle(&mut self) {
+        if let Some(ahead) = &mut self.ahead {
+            ahead.stop();
+        }
+    }
+
+    /// What the container opened, first opened first, as the entry tables name
+    /// it. `None` unless this run was recording.
+    pub fn recorded(&self) -> Option<Vec<Vec<u8>>> {
+        self.recorder.as_ref().map(|recorder| recorder.recorded())
+    }
 }
 
 impl Drop for Mount {
@@ -66,6 +99,12 @@ impl Drop for Mount {
         let Some(session) = self.session.take() else {
             return;
         };
+        // Nothing may be reading the mount as it goes.
+        self.settle();
+        log!(
+            "The container waited for {} files to be fetched",
+            self.served.waited()
+        );
         log!("Unmounting {}", self.at.display());
         // The helper behind an auto-unmounting mount waits for this process to
         // exit, and the session will not finish until the mount goes, so
@@ -115,6 +154,32 @@ fn unmount(at: &Path) -> std::io::Result<()> {
     }
 }
 
+/// The paths, of those given, that this image does not hold as a regular file.
+///
+/// `None` when the image cannot be resolved at all, which is a different thing
+/// from a profile naming files an image does not have: one is a profile that
+/// has gone stale, the other an image nothing could have served in the first
+/// place.
+pub fn absent<'a>(
+    extractor: &RootfsExtractor,
+    descriptors: &[Descriptor],
+    paths: impl Iterator<Item = &'a [u8]>,
+) -> Option<Vec<Vec<u8>>> {
+    let (plan, work, indexes) = extractor.resolved(descriptors)?;
+    drop(indexes);
+    let (tree, _, names) = tree::Tree::build(plan.directories(), plan.tables(), work)?;
+    let absent = paths
+        .filter(|path| {
+            !names
+                .ino(&crate::profile::to_entry_path(path))
+                .and_then(|ino| tree.get(ino))
+                .is_some_and(|node| matches!(node.kind, tree::Kind::File(_)))
+        })
+        .map(<[u8]>::to_vec)
+        .collect();
+    Some(absent)
+}
+
 /// Mounts the image at `rootfs`, or returns `None` when it has to be extracted
 /// instead.
 ///
@@ -127,6 +192,7 @@ pub fn serve(
     layout: &Layout,
     descriptors: &[Descriptor],
     extractor: &RootfsExtractor,
+    fetching: Fetching<'_>,
 ) -> Result<Option<Mount>> {
     if mode == RootfsMode::Extract {
         return Ok(None);
@@ -145,7 +211,8 @@ pub fn serve(
     let Some((plan, work, indexes)) = extractor.resolved(descriptors) else {
         return refuse("the layers have no entry tables or no checkpoint indexes".to_string());
     };
-    let Some((tree, bodies)) = tree::Tree::build(plan.directories(), plan.tables(), work) else {
+    let Some((tree, bodies, names)) = tree::Tree::build(plan.directories(), plan.tables(), work)
+    else {
         return refuse("the resolved image does not describe a whole tree".to_string());
     };
     if let Err(err) = OpenOptions::new().read(true).write(true).open(DEVICE) {
@@ -159,6 +226,9 @@ pub fn serve(
     source.verify(descriptors)?;
 
     std::fs::create_dir_all(backing).io_context(|| format!("creating {backing}"))?;
+    let recorder = fetching
+        .record
+        .then(|| Arc::new(Recorder::new(names.by_ino(tree.len()))));
     let served = fs::Rootfs::new(
         tree,
         bodies,
@@ -167,6 +237,7 @@ pub fn serve(
         backing.as_std_path().to_owned(),
         sys::euid(),
         sys::egid(),
+        recorder.clone(),
     );
 
     // Auto-unmount first, so that a launcher that is killed outright does not
@@ -200,10 +271,22 @@ pub fn serve(
     } else {
         log!("Killing this process will leave the mount behind");
     }
+    let ahead = fetching.profile.map(|profile| {
+        Ahead::start(
+            &served,
+            &names,
+            profile,
+            fetching.barrier,
+            workers().div_ceil(2),
+        )
+    });
     Ok(Some(Mount {
         session: Some(session),
         at: rootfs.as_std_path().to_owned(),
         automatic,
+        ahead,
+        recorder,
+        served,
     }))
 }
 

--- a/source/src/lazy/tree.rs
+++ b/source/src/lazy/tree.rs
@@ -159,6 +159,35 @@ impl Bodies {
     }
 }
 
+/// What the image called each inode, which is the only place the two things
+/// working from a recorded list of paths can agree with it.
+pub struct Names(HashMap<Vec<u8>, u64>);
+
+impl Names {
+    pub fn ino(&self, path: &[u8]) -> Option<u64> {
+        self.0.get(path).copied()
+    }
+
+    /// The image's name for each inode, indexed by inode, empty where an
+    /// inode has none.
+    ///
+    /// Hard linked files have several and take the first in order, so what a
+    /// recording writes down does not depend on which name the container
+    /// happened to open or on the order a hash map gave them up.
+    pub fn by_ino(&self, inodes: usize) -> Vec<Vec<u8>> {
+        let mut names = vec![Vec::new(); inodes];
+        for (path, &ino) in &self.0 {
+            let Some(name) = names.get_mut(ino as usize - 1) else {
+                continue;
+            };
+            if name.is_empty() || path < name {
+                name.clone_from(path);
+            }
+        }
+        names
+    }
+}
+
 impl Tree {
     /// The namespace the image ends up with, or `None` when the plan describes
     /// one that cannot be built: a hard link naming nothing, or an entry whose
@@ -171,7 +200,7 @@ impl Tree {
         directories: &[(Vec<u8>, u32)],
         tables: &[Table],
         work: &Work,
-    ) -> Option<(Tree, Bodies)> {
+    ) -> Option<(Tree, Bodies, Names)> {
         let mut tree = Tree {
             nodes: vec![Node::directory(DEFAULT_DIRECTORY_MODE)],
         };
@@ -222,7 +251,7 @@ impl Tree {
             tree.attach(&mut by_path, &entry.path, target)?;
         }
 
-        Some((tree, bodies))
+        Some((tree, bodies, Names(by_path)))
     }
 
     pub fn get(&self, ino: u64) -> Option<&Node> {
@@ -383,7 +412,7 @@ mod tests {
     #[test]
     fn the_namespace_is_the_one_the_plan_describes() {
         let (directories, tables, work) = image();
-        let (tree, _) = Tree::build(&directories, &tables, &work).expect("tree");
+        let (tree, ..) = Tree::build(&directories, &tables, &work).expect("tree");
 
         let etc = tree.lookup(ROOT, b"etc").expect("etc");
         let passwd = tree.lookup(etc, b"passwd").expect("passwd");
@@ -405,7 +434,7 @@ mod tests {
     #[test]
     fn a_hard_link_is_another_name_for_the_same_inode() {
         let (directories, tables, work) = image();
-        let (tree, _) = Tree::build(&directories, &tables, &work).expect("tree");
+        let (tree, ..) = Tree::build(&directories, &tables, &work).expect("tree");
         let etc = tree.lookup(ROOT, b"etc").expect("etc");
         let passwd = tree.lookup(etc, b"passwd").expect("passwd");
 
@@ -416,7 +445,7 @@ mod tests {
     #[test]
     fn a_subdirectory_is_a_name_for_its_parent() {
         let directories = vec![(b"usr".to_vec(), 0o755), (b"usr/bin".to_vec(), 0o755)];
-        let (tree, _) = Tree::build(&directories, &[], &Work::default()).expect("tree");
+        let (tree, ..) = Tree::build(&directories, &[], &Work::default()).expect("tree");
 
         let usr = tree.lookup(ROOT, b"usr").expect("usr");
         let bin = tree.lookup(usr, b"bin").expect("bin");
@@ -454,7 +483,7 @@ mod tests {
     #[test]
     fn the_last_name_taken_away_takes_the_inode_with_it() {
         let (directories, tables, work) = image();
-        let (mut tree, _) = Tree::build(&directories, &tables, &work).expect("tree");
+        let (mut tree, ..) = Tree::build(&directories, &tables, &work).expect("tree");
         let etc = tree.lookup(ROOT, b"etc").expect("etc");
         let passwd = tree.lookup(etc, b"passwd").expect("passwd");
 
@@ -467,8 +496,25 @@ mod tests {
 
     #[test]
     fn the_root_takes_the_mode_the_image_gives_it() {
-        let (tree, _) =
+        let (tree, ..) =
             Tree::build(&[(b".".to_vec(), 0o750)], &[], &Work::default()).expect("tree");
         assert_eq!(tree.get(ROOT).expect("root").mode, 0o750);
+    }
+
+    #[test]
+    fn every_entry_can_be_found_by_the_name_the_image_gave_it() {
+        let (directories, tables, work) = image();
+        let (tree, _, names) = Tree::build(&directories, &tables, &work).expect("tree");
+        let etc = tree.lookup(ROOT, b"etc").expect("etc");
+        let passwd = tree.lookup(etc, b"passwd").expect("passwd");
+
+        assert_eq!(names.ino(b"etc/passwd"), Some(passwd));
+        assert_eq!(names.ino(b"etc/nothing"), None);
+
+        let by_ino = names.by_ino(tree.len());
+        assert_eq!(by_ino[etc as usize - 1], b"etc");
+        // `etc/same` is the same inode, and the first name in order is what a
+        // recording says whichever of them was opened.
+        assert_eq!(by_ino[passwd as usize - 1], b"etc/passwd");
     }
 }

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -8,6 +8,7 @@ mod image;
 mod launcher;
 mod lazy;
 mod log;
+mod profile;
 mod runtime;
 mod sidecar;
 mod spec;
@@ -18,11 +19,12 @@ use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 
 use crate::bundle::Bundle;
-use crate::cli::{Cli, Command, IndexArgs, RunArgs};
+use crate::cli::{Cli, Command, IndexArgs, ProfileArgs, RootfsMode, RunArgs};
 use crate::error::{Error, Result};
 use crate::extract::RootfsExtractor;
 use crate::image::{Layout, Platform};
 use crate::log::log;
+use crate::profile::Profile;
 use crate::runtime::{ContainerRuntime, RunRequest, Runc};
 use crate::spec::{BindMount, Spec, SpecOptions};
 
@@ -45,6 +47,7 @@ fn main() -> std::process::ExitCode {
         match cli.command {
             Command::Run(args) => run(*args),
             Command::Index(args) => index(args),
+            Command::Profile(args) => check_profile(&args),
         }
     });
     match code {
@@ -87,17 +90,39 @@ fn run(args: RunArgs) -> Result<i32> {
     let mut extractor = RootfsExtractor::new(&rootfs, args.index.as_deref(), args.strict_xattrs)?;
     extractor.plan(&manifest.layers)?;
 
+    let recording = recording_destination(&args, &platform)?;
+    let profile = profile_for(&args.profiles, &platform)?;
+    // A recording that quietly extracted the image records nothing, and says
+    // nothing about why.
+    let mode = match (args.rootfs, &recording) {
+        (RootfsMode::Auto, Some(_)) => RootfsMode::Fuse,
+        (RootfsMode::Extract, Some(_)) => {
+            return Err(Error::Profile {
+                path: "--record-profile".to_string(),
+                message: "has nothing to record from an extracted rootfs, whose files are all \
+                    written before the container starts"
+                    .to_string(),
+            });
+        }
+        (mode, _) => mode,
+    };
+
     // Declared after the bundle so that it unmounts before the bundle it sits
     // in is taken away.
-    let _mount = lazy::serve(
-        args.rootfs,
+    let mut mount = lazy::serve(
+        mode,
         &rootfs,
         &bundle.backing_dir(),
         &layout,
         &manifest.layers,
         &extractor,
+        lazy::Fetching {
+            profile: profile.as_ref(),
+            record: recording.is_some(),
+            barrier: args.prefetch_barrier,
+        },
     )?;
-    if _mount.is_none() {
+    if mount.is_none() {
         extractor.apply(&layout, &manifest.layers)?;
     } else if args.keep_bundle {
         // The rootfs only ever existed as a mount, so what is kept is what the
@@ -156,8 +181,199 @@ fn run(args: RunArgs) -> Result<i32> {
     log!("Handing bundle {} to {}", bundle.dir(), runc.name());
     let result = runc.run(&request);
     runc.delete(&request);
+    // Nothing is waiting on the image any more, however the container ended.
+    if let Some(mount) = mount.as_mut() {
+        mount.settle();
+    }
+    if let (Some(destination), Some(mount)) = (&recording, mount.as_ref()) {
+        record(destination, &platform, &manifest.config.digest, mount)?;
+    }
     log!("Container has exited, cleaning up...");
     result
+}
+
+/// Where this run's reads are written down, or `None` when it is not recording.
+///
+/// The platform is appended here rather than left to the caller: what a
+/// container reads is what the manifest it ran holds, and two platforms
+/// recorded over one name would each undo the other.
+fn recording_destination(args: &RunArgs, platform: &Platform) -> Result<Option<Utf8PathBuf>> {
+    let Some(given) = &args.record_profile else {
+        return Ok(None);
+    };
+    let base = if !given.as_str().is_empty() {
+        given.clone()
+    } else {
+        // `bazel run` exports this; a launcher run from `bazel-bin` does not
+        // have a source tree to write to at all.
+        let workspace = std::env::var("BUILD_WORKSPACE_DIRECTORY").unwrap_or_default();
+        let base = args.profile_base.as_ref().filter(|_| !workspace.is_empty());
+        let Some(base) = base else {
+            return Err(Error::Profile {
+                path: "--record-profile".to_string(),
+                message: "needs a path, since there is no rule and workspace to take one from"
+                    .to_string(),
+            });
+        };
+        Utf8PathBuf::from(workspace).join(base)
+    };
+    Ok(Some(profile::qualified(&base, platform)))
+}
+
+/// The profile recorded for this platform, out of those the caller named.
+fn profile_for(paths: &[Utf8PathBuf], platform: &Platform) -> Result<Option<Profile>> {
+    let wanted = platform.to_string();
+    for path in paths {
+        // A rule can name a profile that has not been recorded yet, which is
+        // how the first recording run gets to happen.
+        let Some(profile) = Profile::read(path)? else {
+            log!("There is no profile at {path} yet");
+            continue;
+        };
+        if profile.platform() != wanted {
+            log!(
+                "Ignoring {path}: recorded for {}, running {wanted}",
+                profile.platform()
+            );
+            continue;
+        }
+        log!(
+            "Read {path}: {} files over {} runs",
+            profile.ordered().len(),
+            profile.runs()
+        );
+        return Ok(Some(profile));
+    }
+    Ok(None)
+}
+
+/// Adds this run's reads to the profile at `destination`.
+///
+/// Merged rather than replacing what is there: one run is one path through a
+/// container, and a profile that only remembers the last one forgets whatever
+/// the run before it found.
+fn record(
+    destination: &Utf8Path,
+    platform: &Platform,
+    image: &str,
+    mount: &lazy::Mount,
+) -> Result<()> {
+    let read = mount.recorded().unwrap_or_default();
+    let mut profile = match Profile::read(destination)? {
+        Some(profile) if profile.platform() != platform.to_string() => {
+            return Err(Error::Profile {
+                path: destination.to_string(),
+                message: format!("was recorded for {}, not {platform}", profile.platform()),
+            });
+        }
+        Some(profile) => profile,
+        None => Profile::empty(platform),
+    };
+    let read: Vec<Vec<u8>> = read
+        .iter()
+        .map(|path| profile::from_entry_path(path))
+        .collect();
+    profile.merge_run(image, &read);
+    profile.write(destination)?;
+    // Recording is asked for outright, so say what came of it whether or not
+    // the run was a verbose one.
+    eprintln!(
+        "recorded {} files this run read into {destination}, {} in all over {} runs",
+        read.len(),
+        profile.ordered().len(),
+        profile.runs()
+    );
+    Ok(())
+}
+
+/// Checks that a profile still describes the image it will be used with.
+///
+/// Fetching ahead from a path an image no longer holds costs a lookup and
+/// nothing else, so this is not about the run failing. It is about a profile
+/// quietly ceasing to describe anything: one recorded against another image,
+/// or left behind by a rename, still looks like a profile and no longer buys
+/// what it claims.
+fn check_profile(args: &ProfileArgs) -> Result<i32> {
+    let fail = |message: String| Error::Profile {
+        path: args.profile.to_string(),
+        message,
+    };
+    let profile =
+        Profile::read(&args.profile)?.ok_or_else(|| fail("does not exist".to_string()))?;
+    if let Some(named) = profile::platform_of(&args.profile)
+        && named != profile.platform()
+    {
+        return Err(fail(format!(
+            "is named for {named} and was recorded for {}",
+            profile.platform()
+        )));
+    }
+
+    let platform = parse_platform(Some(profile.platform()))?;
+    let layout = Layout::open(&args.layout)?;
+    let manifest = layout.resolve_manifest(&platform)?;
+    if !profile.image().is_empty() && profile.image() != manifest.config.digest {
+        log::warn(format!(
+            "{} was recorded against image {}, which is now {}",
+            args.profile,
+            profile.image(),
+            manifest.config.digest
+        ));
+    }
+    if profile.is_empty() {
+        log::warn(format!("{} names no files", args.profile));
+    }
+
+    // Nothing is extracted, but resolving the image is what says which of its
+    // entries survive its own layers, and that is the tree a profile has to
+    // agree with.
+    let scratch = Utf8PathBuf::from_path_buf(std::env::temp_dir())
+        .map_err(|path| {
+            Error::io(
+                format!("temporary directory {} is not valid UTF-8", path.display()),
+                std::io::Error::from(std::io::ErrorKind::InvalidData),
+            )
+        })?
+        .join(format!("rules-oci-runtime-check-{}", sys::random_hex(8)?));
+    let mut extractor = RootfsExtractor::new(&scratch, Some(&args.index), false)?;
+    let checked = extractor
+        .plan(&manifest.layers)
+        .and_then(|()| Ok(lazy::absent(&extractor, &manifest.layers, profile.paths())));
+    let _ = std::fs::remove_dir_all(&scratch);
+
+    let Some(absent) = checked? else {
+        return Err(fail(format!(
+            "cannot be checked against {}: its layers have no entry tables or no checkpoint indexes",
+            args.layout
+        )));
+    };
+    if !absent.is_empty() {
+        let named: Vec<String> = absent
+            .iter()
+            .take(10)
+            .map(|path| String::from_utf8_lossy(path).into_owned())
+            .collect();
+        return Err(fail(format!(
+            "names {} this image does not hold: {}{}",
+            if absent.len() == 1 {
+                "a file".to_string()
+            } else {
+                format!("{} files", absent.len())
+            },
+            named.join(", "),
+            if absent.len() > named.len() {
+                ", ..."
+            } else {
+                ""
+            }
+        )));
+    }
+
+    if let Some(stamp) = &args.stamp {
+        std::fs::write(stamp, "")
+            .map_err(|source| Error::io(format!("writing {stamp}"), source))?;
+    }
+    Ok(0)
 }
 
 fn index(args: IndexArgs) -> Result<i32> {

--- a/source/src/profile.rs
+++ b/source/src/profile.rs
@@ -1,0 +1,476 @@
+//! What a container read last time, so the next run can fetch it before it is
+//! asked for.
+//!
+//! A served rootfs pays for a file when something opens it, one span at a time
+//! and one after another, so a container that reads a hundred files waits a
+//! hundred times. The list of what it read is nearly the same on every run, and
+//! a recorded one turns those waits into work that has already happened.
+//!
+//! Profiles are written by a recording run and read by every run after it, so
+//! the file is a source file: sorted, one path a line, and merged rather than
+//! replaced so that repeated recordings accumulate instead of fighting. What a
+//! container reads depends on which manifest it ran, so the platform is in the
+//! header and in the file name; two platforms recorded to one base name do not
+//! meet.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::error::{Error, IoContext, Result};
+use crate::image::Platform;
+
+/// Bumped when a reader can no longer make sense of an older file.
+const VERSION: u32 = 1;
+
+const MAGIC: &str = "oci-runtime-profile";
+
+/// What every profile file ends with, whatever platform it describes.
+pub const SUFFIX: &str = ".profile";
+
+/// The rootfs itself, as the entry tables spell it.
+const ROOT_ENTRY: &[u8] = b".";
+
+/// How often a path has been read, and how early.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Entry {
+    /// Recording runs that read this path. A path that only one run in ten
+    /// wants is still worth fetching, but this is what says so.
+    pub hits: u64,
+    /// Mean position in the order the recording runs reached it. Fetching
+    /// follows this, so the file the container blocks on first is fetched
+    /// first.
+    pub rank: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Profile {
+    /// The image platform this was recorded against, in `os/arch` spelling.
+    platform: String,
+    /// The image configuration the recording ran, which is what a registry
+    /// calls the image ID. Provenance: an image is rebuilt far more often than
+    /// what it holds changes, so a difference here is worth reporting and not
+    /// worth failing over.
+    image: String,
+    runs: u64,
+    /// Keyed by the absolute path, which is both what is written and what
+    /// sorts the file.
+    entries: BTreeMap<Vec<u8>, Entry>,
+}
+
+impl Profile {
+    pub fn empty(platform: &Platform) -> Profile {
+        Profile {
+            platform: platform.to_string(),
+            image: String::new(),
+            runs: 0,
+            entries: BTreeMap::new(),
+        }
+    }
+
+    /// Reads a profile, or `None` when there is not one there yet. A recording
+    /// run has to be able to create the file it merges into.
+    pub fn read(path: &Utf8Path) -> Result<Option<Profile>> {
+        let text = match std::fs::read(path) {
+            Ok(text) => text,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(Error::io(format!("reading profile {path}"), err)),
+        };
+        Profile::parse(&text, path).map(Some)
+    }
+
+    pub fn parse(text: &[u8], path: &Utf8Path) -> Result<Profile> {
+        let fail = |message: String| Error::Profile {
+            path: path.to_string(),
+            message,
+        };
+        let mut profile = Profile {
+            platform: String::new(),
+            image: String::new(),
+            runs: 0,
+            entries: BTreeMap::new(),
+        };
+        let mut version = None;
+        for (number, line) in text.split(|&byte| byte == b'\n').enumerate() {
+            let line = strip_suffix(line, b'\r');
+            let at = |message: &str| fail(format!("line {}: {message}", number + 1));
+            if line.is_empty() {
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix(b"#") {
+                let rest = String::from_utf8_lossy(rest);
+                if let Some(declared) = rest.trim().strip_prefix(MAGIC) {
+                    version = Some(
+                        declared
+                            .trim()
+                            .parse::<u32>()
+                            .map_err(|_| at("unreadable format version"))?,
+                    );
+                }
+                continue;
+            }
+            if version.is_none() {
+                return Err(fail(format!("does not begin with `# {MAGIC} {VERSION}`")));
+            }
+            let (key, rest) = split_once(line, b' ').ok_or_else(|| at("expected `key value`"))?;
+            let value = || String::from_utf8_lossy(rest).trim().to_string();
+            match key {
+                b"platform" => profile.platform = value(),
+                b"image" => profile.image = value(),
+                b"runs" => {
+                    profile.runs = value().parse().map_err(|_| at("unreadable run count"))?;
+                }
+                _ => {
+                    let (rank, path) =
+                        split_once(rest, b' ').ok_or_else(|| at("expected `hits rank path`"))?;
+                    let entry = Entry {
+                        hits: number_of(key).ok_or_else(|| at("unreadable hit count"))?,
+                        rank: number_of(rank).ok_or_else(|| at("unreadable rank"))?,
+                    };
+                    let path = unescape(path).ok_or_else(|| at("unreadable path"))?;
+                    if !path.starts_with(b"/") {
+                        return Err(at("path is not absolute"));
+                    }
+                    profile.entries.insert(path, entry);
+                }
+            }
+        }
+        match version {
+            None => Err(fail(format!("does not begin with `# {MAGIC} {VERSION}`"))),
+            Some(version) if version > VERSION => Err(fail(format!(
+                "is version {version}, and this launcher reads {VERSION}"
+            ))),
+            Some(_) if profile.platform.is_empty() => Err(fail("names no platform".to_string())),
+            Some(_) => Ok(profile),
+        }
+    }
+
+    /// Adds one run's reads, in the order the container reached them.
+    ///
+    /// Recording is merged rather than replacing what is there: one run of a
+    /// container is one path through it, and a profile that only knows the
+    /// last one forgets everything the run before it found.
+    pub fn merge_run(&mut self, image: &str, order: &[Vec<u8>]) {
+        for (index, path) in order.iter().enumerate() {
+            let index = index as u64;
+            self.entries
+                .entry(path.clone())
+                .and_modify(|entry| {
+                    entry.rank = (entry.rank * entry.hits + index) / (entry.hits + 1);
+                    entry.hits += 1;
+                })
+                .or_insert(Entry {
+                    hits: 1,
+                    rank: index,
+                });
+        }
+        self.runs += 1;
+        self.image = image.to_string();
+    }
+
+    /// The paths to fetch, first read first.
+    pub fn ordered(&self) -> Vec<&[u8]> {
+        let mut paths: Vec<(&Entry, &[u8])> = self
+            .entries
+            .iter()
+            .map(|(path, entry)| (entry, path.as_slice()))
+            .collect();
+        paths.sort_by_key(|(entry, path)| (entry.rank, *path));
+        paths.into_iter().map(|(_, path)| path).collect()
+    }
+
+    pub fn paths(&self) -> impl Iterator<Item = &[u8]> {
+        self.entries.keys().map(Vec::as_slice)
+    }
+
+    pub fn platform(&self) -> &str {
+        &self.platform
+    }
+
+    pub fn image(&self) -> &str {
+        &self.image
+    }
+
+    pub fn runs(&self) -> u64 {
+        self.runs
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Writes the profile where a reviewer can read the diff: header first,
+    /// then a line per path in path order, whatever order they are fetched in.
+    ///
+    /// Written beside the destination and renamed over it, so a run
+    /// interrupted half way through leaves the profile it started with.
+    pub fn write(&self, path: &Utf8Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).io_context(|| format!("creating {parent}"))?;
+        }
+        let staged = path.with_extension(format!("tmp{}", std::process::id()));
+        std::fs::write(&staged, self.render()).io_context(|| format!("writing {staged}"))?;
+        std::fs::rename(&staged, path).io_context(|| format!("writing {path}"))
+    }
+
+    fn render(&self) -> String {
+        let mut out = format!("# {MAGIC} {VERSION}\n");
+        let _ = writeln!(out, "platform {}", self.platform);
+        if !self.image.is_empty() {
+            let _ = writeln!(out, "image {}", self.image);
+        }
+        let _ = writeln!(out, "runs {}", self.runs);
+        for (path, entry) in &self.entries {
+            let _ = writeln!(out, "{} {} {}", entry.hits, entry.rank, escape(path));
+        }
+        out
+    }
+}
+
+/// Where a recording for `platform` goes, given the base name a rule or a
+/// caller chose.
+///
+/// The qualifier is what stops a recording made on one platform from landing
+/// on another's: the two ran different manifests and read different files.
+pub fn qualified(base: &Utf8Path, platform: &Platform) -> Utf8PathBuf {
+    let mut name = format!(
+        "{}.{}-{}",
+        base.file_name().unwrap_or_default(),
+        platform.os,
+        platform.architecture
+    );
+    if let Some(variant) = platform.variant.as_deref().filter(|v| !v.is_empty()) {
+        name.push('-');
+        name.push_str(variant);
+    }
+    name.push_str(SUFFIX);
+    base.with_file_name(name)
+}
+
+/// The platform a profile file name claims, or `None` when it is not named
+/// like one.
+pub fn platform_of(path: &Utf8Path) -> Option<String> {
+    let name = path.file_name()?.strip_suffix(SUFFIX)?;
+    let (_, qualifier) = name.rsplit_once('.')?;
+    let (os, rest) = qualifier.split_once('-')?;
+    let (architecture, variant) = match rest.split_once('-') {
+        Some((architecture, variant)) => (architecture, Some(variant)),
+        None => (rest, None),
+    };
+    Some(
+        Platform {
+            os: os.to_string(),
+            architecture: architecture.to_string(),
+            variant: variant.map(str::to_string),
+        }
+        .to_string(),
+    )
+}
+
+/// A profile path as the entry tables spell it: relative to the rootfs, with
+/// the rootfs itself spelled `.`.
+pub fn to_entry_path(path: &[u8]) -> Vec<u8> {
+    match path.strip_prefix(b"/") {
+        Some(rest) if rest.is_empty() => ROOT_ENTRY.to_vec(),
+        Some(rest) => rest.to_vec(),
+        None => path.to_vec(),
+    }
+}
+
+/// An entry table path as a profile spells it: absolute, which is how the
+/// container named it and how a reader recognises it.
+pub fn from_entry_path(path: &[u8]) -> Vec<u8> {
+    if path == ROOT_ENTRY {
+        return b"/".to_vec();
+    }
+    let mut out = Vec::with_capacity(path.len() + 1);
+    out.push(b'/');
+    out.extend_from_slice(path);
+    out
+}
+
+/// Renders a path as one line of a text file.
+///
+/// Paths are bytes and may hold anything but `/` and NUL, so the escaping has
+/// to survive a round trip through a line. Valid UTF-8 is left alone beyond
+/// the characters that would break the format, since a profile nobody can read
+/// is a profile nobody reviews.
+fn escape(path: &[u8]) -> String {
+    let utf8 = std::str::from_utf8(path).is_ok();
+    let mut out: Vec<u8> = Vec::with_capacity(path.len());
+    for &byte in path {
+        match byte {
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            0x20..=0x7e => out.push(byte),
+            // Whole multi-byte characters, pushed as they came.
+            _ if utf8 && byte >= 0x80 => out.push(byte),
+            _ => out.extend_from_slice(format!("\\x{byte:02x}").as_bytes()),
+        }
+    }
+    // Everything added above is either ASCII or a byte of the valid UTF-8 that
+    // was passed through whole.
+    String::from_utf8(out).expect("escaped paths are UTF-8")
+}
+
+/// Undoes [`escape`].
+fn unescape(line: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(line.len());
+    let mut bytes = line.iter().copied();
+    while let Some(byte) = bytes.next() {
+        if byte != b'\\' {
+            out.push(byte);
+            continue;
+        }
+        match bytes.next()? {
+            b'\\' => out.push(b'\\'),
+            b'n' => out.push(b'\n'),
+            b'r' => out.push(b'\r'),
+            b'x' => {
+                let hex = [bytes.next()?, bytes.next()?];
+                let hex = std::str::from_utf8(&hex).ok()?;
+                out.push(u8::from_str_radix(hex, 16).ok()?);
+            }
+            _ => return None,
+        }
+    }
+    Some(out)
+}
+
+fn number_of(bytes: &[u8]) -> Option<u64> {
+    std::str::from_utf8(bytes).ok()?.trim().parse().ok()
+}
+
+fn split_once(line: &[u8], separator: u8) -> Option<(&[u8], &[u8])> {
+    let at = line.iter().position(|&byte| byte == separator)?;
+    Some((&line[..at], &line[at + 1..]))
+}
+
+fn strip_suffix(line: &[u8], byte: u8) -> &[u8] {
+    match line.split_last() {
+        Some((&last, rest)) if last == byte => rest,
+        _ => line,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn platform() -> Platform {
+        Platform {
+            os: "linux".to_string(),
+            architecture: "amd64".to_string(),
+            variant: None,
+        }
+    }
+
+    fn parse(text: &str) -> Result<Profile> {
+        Profile::parse(text.as_bytes(), Utf8Path::new("p.linux-amd64.profile"))
+    }
+
+    #[test]
+    fn a_recorded_run_round_trips() {
+        let mut profile = Profile::empty(&platform());
+        profile.merge_run("sha256:aa", &[b"/bin/sh".to_vec(), b"/etc/passwd".to_vec()]);
+        let parsed = parse(&profile.render()).expect("profile");
+        assert_eq!(parsed.platform(), "linux/amd64");
+        assert_eq!(parsed.image(), "sha256:aa");
+        assert_eq!(parsed.runs(), 1);
+        assert_eq!(parsed.ordered(), [b"/bin/sh".as_slice(), b"/etc/passwd"]);
+    }
+
+    #[test]
+    fn entries_are_written_in_path_order_and_fetched_in_read_order() {
+        let mut profile = Profile::empty(&platform());
+        profile.merge_run("", &[b"/z".to_vec(), b"/a".to_vec()]);
+        let rendered = profile.render();
+        let written: Vec<&str> = rendered
+            .lines()
+            .filter(|line| line.starts_with('1'))
+            .collect();
+        assert_eq!(written, ["1 1 /a", "1 0 /z"]);
+        assert_eq!(profile.ordered(), [b"/z".as_slice(), b"/a"]);
+    }
+
+    #[test]
+    fn merging_counts_runs_and_averages_the_rank() {
+        let mut profile = Profile::empty(&platform());
+        profile.merge_run("", &[b"/a".to_vec(), b"/b".to_vec()]);
+        profile.merge_run("", &[b"/b".to_vec(), b"/c".to_vec()]);
+        assert_eq!(profile.runs(), 2);
+        // `/b` was second, then first: reached before `/c`, which one run
+        // never asked for at all.
+        assert_eq!(profile.ordered(), [b"/a".as_slice(), b"/b", b"/c"]);
+        assert_eq!(
+            profile.entries[b"/b".as_slice()],
+            Entry { hits: 2, rank: 0 }
+        );
+        assert_eq!(
+            profile.entries[b"/a".as_slice()],
+            Entry { hits: 1, rank: 0 }
+        );
+    }
+
+    #[test]
+    fn awkward_paths_survive_a_line() {
+        let awkward: Vec<Vec<u8>> = vec![
+            b"/a path/with spaces".to_vec(),
+            b"/back\\slash".to_vec(),
+            b"/new\nline".to_vec(),
+            b"/caf\xc3\xa9/menu".to_vec(),
+            vec![b'/', 0xff, 0xfe],
+        ];
+        let mut profile = Profile::empty(&platform());
+        profile.merge_run("", &awkward);
+        let parsed = parse(&profile.render()).expect("profile");
+        let mut expected = awkward.clone();
+        expected.sort();
+        let read: Vec<Vec<u8>> = parsed.paths().map(<[u8]>::to_vec).collect();
+        assert_eq!(read, expected);
+    }
+
+    #[test]
+    fn a_file_that_is_not_a_profile_is_refused() {
+        assert!(parse("/bin/sh\n").is_err());
+        assert!(parse("# oci-runtime-profile 99\nplatform linux/amd64\n").is_err());
+        assert!(parse("# oci-runtime-profile 1\n1 0 /bin/sh\n").is_err());
+        assert!(parse("# oci-runtime-profile 1\nplatform linux/amd64\n1 0 bin/sh\n").is_err());
+    }
+
+    #[test]
+    fn the_file_name_carries_the_platform() {
+        let arm = Platform {
+            os: "linux".to_string(),
+            architecture: "arm".to_string(),
+            variant: Some("v7".to_string()),
+        };
+        assert_eq!(
+            qualified(Utf8Path::new("profiles/container"), &platform()),
+            "profiles/container.linux-amd64.profile"
+        );
+        assert_eq!(
+            qualified(Utf8Path::new("profiles/container"), &arm),
+            "profiles/container.linux-arm-v7.profile"
+        );
+        assert_eq!(
+            platform_of(Utf8Path::new("profiles/container.linux-amd64.profile")).as_deref(),
+            Some("linux/amd64")
+        );
+        assert_eq!(
+            platform_of(Utf8Path::new("profiles/container.linux-arm-v7.profile")).as_deref(),
+            Some("linux/arm/v7")
+        );
+        assert_eq!(platform_of(Utf8Path::new("container.profile")), None);
+    }
+
+    #[test]
+    fn profile_paths_and_entry_paths_convert_both_ways() {
+        assert_eq!(to_entry_path(b"/etc/passwd"), b"etc/passwd");
+        assert_eq!(to_entry_path(b"/"), b".");
+        assert_eq!(from_entry_path(b"etc/passwd"), b"/etc/passwd");
+        assert_eq!(from_entry_path(b"."), b"/");
+    }
+}


### PR DESCRIPTION
The advantage of FUSE is that extraction can be deferred, the disadvantage is that those lazy extractions can slow down startup.

This PR adds profiling support, which is essentially a list of files to be eagerly extracted, in the order they are accessed. Once the first _n_ needed files have been extracted, the container is started with remaining files listed in the profile extracting in the background (with priority given to new file reads should expectations not match).